### PR TITLE
fix: restore bundled images after loading archive (Issue #3)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -189,6 +189,8 @@
 					imageStore.setDeviceImage(deviceSlug, 'rear', deviceImages.rear);
 				}
 			}
+			// Reload bundled images (they were cleared above but not saved in archives)
+			imageStore.loadBundledImages();
 
 			layoutStore.loadLayout(layout);
 			layoutStore.markClean();

--- a/src/tests/image-store.test.ts
+++ b/src/tests/image-store.test.ts
@@ -392,4 +392,52 @@ describe('Image Store', () => {
 			expect(userImages.size).toBe(0);
 		});
 	});
+
+	describe('bundled images after clear (Issue #3)', () => {
+		it('loses bundled images after clearAllImages without reload', () => {
+			const store = getImageStore();
+
+			// Load bundled images (simulates app mount)
+			store.loadBundledImages();
+			expect(store.hasImage('1u-server', 'front')).toBe(true);
+
+			// Clear all (simulates file load)
+			store.clearAllImages();
+
+			// Bundled images are gone!
+			expect(store.hasImage('1u-server', 'front')).toBe(false);
+		});
+
+		it('restores bundled images after clearAllImages + loadBundledImages', () => {
+			const store = getImageStore();
+
+			// Load bundled images (simulates app mount)
+			store.loadBundledImages();
+			expect(store.hasImage('1u-server', 'front')).toBe(true);
+
+			// Clear all (simulates file load)
+			store.clearAllImages();
+
+			// Reload bundled images (the fix!)
+			store.loadBundledImages();
+
+			// Bundled images are restored
+			expect(store.hasImage('1u-server', 'front')).toBe(true);
+		});
+
+		it('preserves user images when reloading bundled images', () => {
+			const store = getImageStore();
+
+			// Simulate file load with user images
+			store.clearAllImages();
+			store.setDeviceImage('my-custom-device', 'front', createMockImageData('custom.png'));
+
+			// Reload bundled images
+			store.loadBundledImages();
+
+			// Both user and bundled images should exist
+			expect(store.hasImage('my-custom-device', 'front')).toBe(true);
+			expect(store.hasImage('1u-server', 'front')).toBe(true);
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Fixed bug where bundled device images were lost after loading a .rackarr.zip archive
- Root cause: `clearAllImages()` cleared bundled images but `loadBundledImages()` was not called after restoring user images
- Added `loadBundledImages()` call after image restoration in `handleLoad()`
- Added tests documenting this behavior in `src/tests/image-store.test.ts`

Closes #3

## Test plan
- [x] Unit tests added for bundled image persistence after clear
- [x] All 397 existing tests pass
- [x] Verified fix in App.svelte restores bundled images after load

🤖 Generated with [Claude Code](https://claude.com/claude-code)