### PR TITLE
fix: use app version in layout instead of hardcoded value (Issue #4)

### DIFF
--- a/src/lib/utils/serialization.ts
+++ b/src/lib/utils/serialization.ts
@@ -4,6 +4,7 @@
 
 import type { Layout, Rack, FormFactor } from '$lib/types';
 import { getStarterLibrary } from '$lib/data/starterLibrary';
+import { VERSION } from '$lib/version';
 
 /**
  * Create a new empty layout
@@ -12,7 +13,7 @@ import { getStarterLibrary } from '$lib/data/starterLibrary';
  */
 export function createLayout(name: string = 'Racky McRackface'): Layout {
 	return {
-		version: '0.2.0',
+		version: VERSION,
 		name,
 		rack: createDefaultRack(name),
 		device_types: getStarterLibrary(),

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getLayoutStore, resetLayoutStore } from '$lib/stores/layout.svelte';
 import type { Layout } from '$lib/types';
+import { VERSION } from '$lib/version';
 
 describe('Layout Store (v0.2)', () => {
 	beforeEach(() => {
@@ -9,10 +10,10 @@ describe('Layout Store (v0.2)', () => {
 	});
 
 	describe('initial state', () => {
-		it('initializes with a v0.2 layout', () => {
+		it('initializes with correct app version', () => {
 			const store = getLayoutStore();
 			expect(store.layout.name).toBe('Racky McRackface');
-			expect(store.layout.version).toBe('0.2.0');
+			expect(store.layout.version).toBe(VERSION);
 			// v0.2 has a single rack, not an array
 			expect(store.layout.rack).toBeDefined();
 			expect(store.layout.rack.devices).toEqual([]);


### PR DESCRIPTION
## Summary
- Fixed layout version field being hardcoded to `0.2.0`
- Now uses `VERSION` from `$lib/version` (injected from package.json at build time)
- Allows correlation of saved files with app version for debugging and migration

Closes #4

## Test plan
- [x] Updated test to verify version matches app version
- [x] All 1840 tests pass
- [x] Version now reflects actual app version (0.5.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)