### PR TITLE
fix: device images extend past rack rails for realistic appearance (Issue #9)

### DIFF
--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -90,11 +90,19 @@
 	// Rail width (matches Rack.svelte)
 	const RAIL_WIDTH = 17;
 
+	// Image overflow: how far device images extend past rack rails (Issue #9)
+	// Real equipment extends past the rails; this creates realistic front-mounting appearance
+	const IMAGE_OVERFLOW = 8;
+
 	// Position calculation (SVG y-coordinate, origin at top)
 	// y = (rackHeight - position - device.u_height + 1) * uHeight
 	const yPosition = $derived((rackHeight - position - device.u_height + 1) * uHeight);
 	const deviceHeight = $derived(device.u_height * uHeight);
 	const deviceWidth = $derived(rackWidth - RAIL_WIDTH * 2);
+
+	// Image dimensions extend past device rect for realistic appearance
+	const imageX = $derived(showImage ? -IMAGE_OVERFLOW : 0);
+	const imageWidth = $derived(showImage ? deviceWidth + IMAGE_OVERFLOW * 2 : deviceWidth);
 
 	// Aria label for accessibility
 	const ariaLabel = $derived(
@@ -178,12 +186,12 @@
 
 	<!-- Device content: Image or Label -->
 	{#if showImage}
-		<!-- Device image -->
+		<!-- Device image: extends past rack rails for realistic front-mounting appearance -->
 		<image
 			class="device-image"
-			x="0"
+			x={imageX}
 			y="0"
-			width={deviceWidth}
+			width={imageWidth}
 			height={deviceHeight}
 			href={deviceImageUrl}
 			preserveAspectRatio="xMidYMid slice"

--- a/src/tests/RackDevice.test.ts
+++ b/src/tests/RackDevice.test.ts
@@ -9,6 +9,7 @@ describe('RackDevice SVG Component', () => {
 	const U_HEIGHT = 22;
 	const RACK_WIDTH = 220;
 	const RAIL_WIDTH = 17;
+	const IMAGE_OVERFLOW = 8; // Images extend past rails for realistic appearance
 
 	const mockDevice: DeviceType = {
 		slug: 'device-1',
@@ -386,7 +387,7 @@ describe('RackDevice SVG Component', () => {
 			expect(image?.getAttribute('href')).toBe('data:image/png;base64,cmVhcg==');
 		});
 
-		it('image scales to fit device dimensions', () => {
+		it('image scales to fit device dimensions with overflow', () => {
 			const imageStore = getImageStore();
 			imageStore.setDeviceImage(mockDevice.slug, 'front', mockImageData);
 
@@ -395,10 +396,13 @@ describe('RackDevice SVG Component', () => {
 			});
 
 			const image = container.querySelector('.device-image');
-			const expectedWidth = RACK_WIDTH - RAIL_WIDTH * 2;
+			// Image extends past rack rails by IMAGE_OVERFLOW on each side
+			const expectedWidth = RACK_WIDTH - RAIL_WIDTH * 2 + IMAGE_OVERFLOW * 2;
 			const expectedHeight = U_HEIGHT;
 			expect(image?.getAttribute('width')).toBe(String(expectedWidth));
 			expect(image?.getAttribute('height')).toBe(String(expectedHeight));
+			// Image is positioned at negative x to extend past left rail
+			expect(image?.getAttribute('x')).toBe(String(-IMAGE_OVERFLOW));
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Device images now extend 8px past rack rails on each side in image mode
- Creates realistic front-mounting appearance where equipment overlaps rails
- Device rect and hit area remain within rack interior (unchanged behavior)

Closes #9

## Test plan
- [x] Updated test to verify image dimensions include overflow
- [x] Added assertion for negative x position
- [x] All 1840 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)