### PR TITLE
fix: rename Help button to About (Issue #16)

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -279,10 +279,10 @@
 
 		<div class="separator" aria-hidden="true"></div>
 
-		<Tooltip text="Help & Shortcuts" shortcut="?" position="bottom">
-			<button class="toolbar-action-btn" aria-label="Help" onclick={onhelp} data-testid="btn-help">
+		<Tooltip text="About & Shortcuts" shortcut="?" position="bottom">
+			<button class="toolbar-action-btn" aria-label="About" onclick={onhelp} data-testid="btn-about">
 				<IconHelp size={16} />
-				<span>Help</span>
+				<span>About</span>
 			</button>
 		</Tooltip>
 	</div>

--- a/src/lib/components/ToolbarDrawer.svelte
+++ b/src/lib/components/ToolbarDrawer.svelte
@@ -217,9 +217,9 @@
 				<span>Reset View</span>
 				<kbd class="drawer-shortcut">F</kbd>
 			</button>
-			<button class="drawer-item" aria-label="Help" onclick={() => handleAction(onhelp)}>
+			<button class="drawer-item" aria-label="About" onclick={() => handleAction(onhelp)}>
 				<IconHelp size={18} />
-				<span>Help</span>
+				<span>About</span>
 				<kbd class="drawer-shortcut">?</kbd>
 			</button>
 		</section>

--- a/src/tests/Toolbar.test.ts
+++ b/src/tests/Toolbar.test.ts
@@ -29,7 +29,7 @@ describe('Toolbar Component', () => {
 			expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
 			expect(screen.getByRole('button', { name: /reset view/i })).toBeInTheDocument();
 			expect(screen.getByRole('button', { name: /toggle theme/i })).toBeInTheDocument();
-			expect(screen.getByRole('button', { name: /help/i })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: /about/i })).toBeInTheDocument();
 		});
 	});
 
@@ -138,11 +138,11 @@ describe('Toolbar Component', () => {
 			expect(onToggleTheme).toHaveBeenCalledTimes(1);
 		});
 
-		it('dispatches help event when Help clicked', async () => {
+		it('dispatches help event when About clicked', async () => {
 			const onHelp = vi.fn();
 			render(Toolbar, { props: { onhelp: onHelp } });
 
-			await fireEvent.click(screen.getByRole('button', { name: /help/i }));
+			await fireEvent.click(screen.getByRole('button', { name: /about/i }));
 			expect(onHelp).toHaveBeenCalledTimes(1);
 		});
 	});

--- a/src/tests/ToolbarDrawer.test.ts
+++ b/src/tests/ToolbarDrawer.test.ts
@@ -108,13 +108,13 @@ describe('ToolbarDrawer Component', () => {
 			expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
 		});
 
-		it('renders view group with display mode, airflow, reset view, help', () => {
+		it('renders view group with display mode, airflow, reset view, about', () => {
 			render(ToolbarDrawer, { props: { open: true } });
 
 			expect(screen.getByRole('button', { name: /mode/i })).toBeInTheDocument();
 			expect(screen.getByRole('button', { name: /airflow/i })).toBeInTheDocument();
 			expect(screen.getByRole('button', { name: /reset view/i })).toBeInTheDocument();
-			expect(screen.getByRole('button', { name: /help/i })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: /about/i })).toBeInTheDocument();
 		});
 
 		it('clicking menu item calls action and closes drawer', async () => {

--- a/src/tests/ToolbarResponsive.test.ts
+++ b/src/tests/ToolbarResponsive.test.ts
@@ -40,7 +40,7 @@ describe('Toolbar Responsive Structure', () => {
 			expect(textsFound).toContain('New Rack');
 			expect(textsFound).toContain('Save');
 			expect(textsFound).toContain('Export');
-			expect(textsFound).toContain('Help');
+			expect(textsFound).toContain('About');
 		});
 	});
 
@@ -55,11 +55,11 @@ describe('Toolbar Responsive Structure', () => {
 			expect(logoTitle?.querySelector('text')?.textContent).toBe('Rackarr');
 		});
 
-		it('brand section does not contain tagline (moved to Help)', () => {
+		it('brand section does not contain tagline (moved to About)', () => {
 			const { container } = render(Toolbar);
 
 			// Tagline was removed from toolbar to prevent overlap issues
-			// It is now displayed in the Help panel instead
+			// It is now displayed in the About panel instead
 			const tagline = container.querySelector('.brand-tagline');
 			expect(tagline).not.toBeInTheDocument();
 		});

--- a/src/tests/ToolbarTooltips.test.ts
+++ b/src/tests/ToolbarTooltips.test.ts
@@ -97,25 +97,25 @@ describe('Toolbar Tooltips', () => {
 			expect(shortcut).toHaveTextContent('Del');
 		});
 
-		it('Help button shows shortcut in tooltip', async () => {
+		it('About button shows shortcut in tooltip', async () => {
 			const { container } = render(Toolbar, {
 				props: { theme: 'dark' }
 			});
 
 			const tooltipWrappers = container.querySelectorAll('.tooltip-wrapper');
-			const helpWrapper = Array.from(tooltipWrappers).find((wrapper) => {
+			const aboutWrapper = Array.from(tooltipWrappers).find((wrapper) => {
 				const btn = wrapper.querySelector('button');
-				return btn?.textContent?.includes('Help');
+				return btn?.textContent?.includes('About');
 			});
 
-			expect(helpWrapper).toBeTruthy();
+			expect(aboutWrapper).toBeTruthy();
 
-			const trigger = helpWrapper!.querySelector('.tooltip-trigger');
+			const trigger = aboutWrapper!.querySelector('.tooltip-trigger');
 			await fireEvent.mouseEnter(trigger!);
 			vi.advanceTimersByTime(500);
 			await tick();
 
-			const shortcut = helpWrapper!.querySelector('.tooltip-shortcut');
+			const shortcut = aboutWrapper!.querySelector('.tooltip-shortcut');
 			expect(shortcut).toBeInTheDocument();
 			expect(shortcut).toHaveTextContent('?');
 		});


### PR DESCRIPTION
## Summary
- Renamed toolbar button from "Help" to "About"
- Updated tooltip text from "Help & Shortcuts" to "About & Shortcuts"
- Updated all related tests

Closes #16

## Test plan
- [x] All 1840 tests pass
- [x] Button text, aria-label, and tooltip updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)