### PR TITLE
fix: graceful degradation for blob handling in archive extraction

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -177,7 +177,7 @@
 			}
 
 			// Load folder archive (.rackarr.zip)
-			const { layout, images } = await extractFolderArchive(file);
+			const { layout, images, failedImages } = await extractFolderArchive(file);
 
 			// Clear and restore images from archive
 			imageStore.clearAllImages();
@@ -201,7 +201,16 @@
 				canvasStore.fitAll(layoutStore.rack ? [layoutStore.rack] : []);
 			});
 
-			toastStore.showToast('Layout loaded successfully', 'success');
+			// Show appropriate toast based on image loading results
+			if (failedImages.length > 0) {
+				const count = failedImages.length;
+				toastStore.showToast(
+					`Layout loaded with ${count} image${count > 1 ? 's' : ''} that couldn't be read`,
+					'warning'
+				);
+			} else {
+				toastStore.showToast('Layout loaded successfully', 'success');
+			}
 
 			// Track load event
 			const deviceCount = layoutStore.rack?.devices.length ?? 0;


### PR DESCRIPTION
## Summary

- `blobToDataUrl` now returns `null` instead of throwing on failure
- Type-safe result handling (check for string instead of unsafe cast)
- `extractFolderArchive` returns `failedImages` array for caller to handle
- App shows warning toast when images fail to load instead of crashing
- Continue loading remaining images when one fails

## Test plan

- [x] Added tests for graceful failure handling
- [x] All 1843 tests pass
- [x] Build succeeds

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)