### PR TITLE
test: add comprehensive tests for racksToPositions function (#36)

### DIFF
--- a/src/tests/canvas-utils.test.ts
+++ b/src/tests/canvas-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { calculateRacksBoundingBox, calculateFitAll } from '$lib/utils/canvas';
+import {
+	calculateRacksBoundingBox,
+	calculateFitAll,
+	racksToPositions
+} from '$lib/utils/canvas';
+import { createTestRack } from './factories';
 
 describe('calculateRacksBoundingBox', () => {
 	it('returns zero bounds for empty array', () => {
@@ -134,5 +139,216 @@ describe('calculateFitAll', () => {
 		const resultLarge = calculateFitAll(racks, 1000, 1000);
 		// Larger viewport should allow for larger zoom (up to cap)
 		expect(resultLarge.zoom).toBeGreaterThanOrEqual(resultSmall.zoom);
+	});
+});
+
+// =============================================================================
+// racksToPositions Tests
+// =============================================================================
+
+// Constants matching canvas.ts
+const U_HEIGHT = 22;
+const RACK_WIDTH = 220;
+const RAIL_WIDTH = 17;
+const RACK_PADDING = 18;
+const RACK_GAP = 24;
+const RACK_ROW_PADDING = 16;
+const DUAL_VIEW_GAP = 24;
+const DUAL_VIEW_EXTRA_HEIGHT = 56;
+
+// Helper to calculate expected rack height
+const getRackHeight = (height: number) =>
+	RACK_PADDING + RAIL_WIDTH * 2 + height * U_HEIGHT + DUAL_VIEW_EXTRA_HEIGHT;
+
+// Helper to get dual-view width
+const getDualViewWidth = () => RACK_WIDTH * 2 + DUAL_VIEW_GAP;
+
+describe('racksToPositions', () => {
+	describe('empty array handling', () => {
+		it('returns empty array for empty input', () => {
+			const result = racksToPositions([]);
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe('single rack positioning', () => {
+		it('positions single rack at rack-row padding offset', () => {
+			const rack = createTestRack({ height: 42, position: 0 });
+			const result = racksToPositions([rack]);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].x).toBe(RACK_ROW_PADDING);
+			expect(result[0].y).toBe(RACK_ROW_PADDING);
+		});
+
+		it('calculates correct width for dual-view mode', () => {
+			const rack = createTestRack({ height: 42, position: 0 });
+			const result = racksToPositions([rack]);
+
+			// Width = 2 * RACK_WIDTH + DUAL_VIEW_GAP = 2 * 220 + 24 = 464
+			expect(result[0].width).toBe(getDualViewWidth());
+		});
+
+		it('calculates correct height based on U count', () => {
+			const rack = createTestRack({ height: 42, position: 0 });
+			const result = racksToPositions([rack]);
+
+			// Height = RACK_PADDING + RAIL_WIDTH * 2 + height * U_HEIGHT + DUAL_VIEW_EXTRA_HEIGHT
+			// = 18 + 17 * 2 + 42 * 22 + 56 = 18 + 34 + 924 + 56 = 1032
+			expect(result[0].height).toBe(getRackHeight(42));
+		});
+
+		it('handles different rack heights', () => {
+			const smallRack = createTestRack({ height: 12, position: 0 });
+			const largeRack = createTestRack({ height: 48, position: 0 });
+
+			const smallResult = racksToPositions([smallRack]);
+			const largeResult = racksToPositions([largeRack]);
+
+			expect(smallResult[0].height).toBe(getRackHeight(12));
+			expect(largeResult[0].height).toBe(getRackHeight(48));
+			expect(largeResult[0].height).toBeGreaterThan(smallResult[0].height);
+		});
+	});
+
+	describe('multiple rack positioning', () => {
+		it('positions racks side by side with gap', () => {
+			const rack1 = createTestRack({ height: 42, position: 0 });
+			const rack2 = createTestRack({ height: 42, position: 1 });
+			const result = racksToPositions([rack1, rack2]);
+
+			expect(result).toHaveLength(2);
+			// First rack at row padding
+			expect(result[0].x).toBe(RACK_ROW_PADDING);
+			// Second rack at: RACK_ROW_PADDING + getDualViewWidth() + RACK_GAP
+			expect(result[1].x).toBe(RACK_ROW_PADDING + getDualViewWidth() + RACK_GAP);
+		});
+
+		it('sorts racks by position', () => {
+			const rack1 = createTestRack({ height: 42, position: 2 });
+			const rack2 = createTestRack({ height: 42, position: 0 });
+			const rack3 = createTestRack({ height: 42, position: 1 });
+			const result = racksToPositions([rack1, rack2, rack3]);
+
+			expect(result).toHaveLength(3);
+			// All should have same height, verify they're in order by x position
+			expect(result[0].x).toBeLessThan(result[1].x);
+			expect(result[1].x).toBeLessThan(result[2].x);
+		});
+
+		it('vertically aligns racks of different heights to bottom', () => {
+			const shortRack = createTestRack({ height: 24, position: 0 });
+			const tallRack = createTestRack({ height: 42, position: 1 });
+			const result = racksToPositions([shortRack, tallRack]);
+
+			// Both should end at the same y + height (bottom aligned to max height)
+			const shortBottom = result[0].y + result[0].height;
+			const tallBottom = result[1].y + result[1].height;
+			expect(shortBottom).toBe(tallBottom);
+
+			// Short rack should have larger y to account for height difference
+			expect(result[0].y).toBeGreaterThan(result[1].y);
+		});
+
+		it('positions three racks correctly', () => {
+			const rack1 = createTestRack({ height: 42, position: 0 });
+			const rack2 = createTestRack({ height: 42, position: 1 });
+			const rack3 = createTestRack({ height: 42, position: 2 });
+			const result = racksToPositions([rack1, rack2, rack3]);
+
+			expect(result).toHaveLength(3);
+
+			// Verify spacing between racks
+			const spacing01 = result[1].x - (result[0].x + result[0].width);
+			const spacing12 = result[2].x - (result[1].x + result[1].width);
+
+			expect(spacing01).toBe(RACK_GAP);
+			expect(spacing12).toBe(RACK_GAP);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('handles minimum rack height (1U)', () => {
+			const rack = createTestRack({ height: 1, position: 0 });
+			const result = racksToPositions([rack]);
+
+			expect(result[0].height).toBe(getRackHeight(1));
+			expect(result[0].height).toBeGreaterThan(0);
+		});
+
+		it('handles very tall racks', () => {
+			const rack = createTestRack({ height: 100, position: 0 });
+			const result = racksToPositions([rack]);
+
+			expect(result[0].height).toBe(getRackHeight(100));
+		});
+
+		it('handles racks with same position value', () => {
+			// Edge case - shouldn't happen in practice but should be handled
+			const rack1 = createTestRack({ height: 42, position: 0 });
+			const rack2 = createTestRack({ height: 42, position: 0 });
+			const result = racksToPositions([rack1, rack2]);
+
+			expect(result).toHaveLength(2);
+			// Both should be positioned
+			expect(result[0].x).toBeDefined();
+			expect(result[1].x).toBeDefined();
+		});
+
+		it('preserves original racks array (non-mutating)', () => {
+			const racks = [
+				createTestRack({ height: 42, position: 1 }),
+				createTestRack({ height: 42, position: 0 })
+			];
+			const originalOrder = [...racks];
+
+			racksToPositions(racks);
+
+			// Original array should not be modified
+			expect(racks[0].position).toBe(originalOrder[0].position);
+			expect(racks[1].position).toBe(originalOrder[1].position);
+		});
+	});
+
+	describe('position calculation accuracy', () => {
+		it('produces consistent results for same input', () => {
+			const rack = createTestRack({ height: 42, position: 0 });
+			const result1 = racksToPositions([rack]);
+			const result2 = racksToPositions([rack]);
+
+			expect(result1).toEqual(result2);
+		});
+
+		it('all positions have positive coordinates', () => {
+			const racks = [
+				createTestRack({ height: 42, position: 0 }),
+				createTestRack({ height: 24, position: 1 }),
+				createTestRack({ height: 48, position: 2 })
+			];
+			const result = racksToPositions(racks);
+
+			for (const pos of result) {
+				expect(pos.x).toBeGreaterThanOrEqual(0);
+				expect(pos.y).toBeGreaterThanOrEqual(0);
+				expect(pos.width).toBeGreaterThan(0);
+				expect(pos.height).toBeGreaterThan(0);
+			}
+		});
+
+		it('no racks overlap horizontally', () => {
+			const racks = [
+				createTestRack({ height: 42, position: 0 }),
+				createTestRack({ height: 42, position: 1 }),
+				createTestRack({ height: 42, position: 2 })
+			];
+			const result = racksToPositions(racks);
+
+			for (let i = 0; i < result.length - 1; i++) {
+				const current = result[i];
+				const next = result[i + 1];
+				const currentRight = current.x + current.width;
+				expect(currentRight).toBeLessThan(next.x);
+			}
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Add 16 new tests for the previously untested `racksToPositions` function
- Increase canvas-utils test coverage from 16 to 32 tests
- All 3 exported functions now have comprehensive test coverage

## Changes
- `src/tests/canvas-utils.test.ts`: Extended with racksToPositions tests

## Test Coverage

| Function | Tests | Status |
|----------|-------|--------|
| `calculateRacksBoundingBox` | 6 tests | ✅ (existing) |
| `calculateFitAll` | 10 tests | ✅ (existing) |
| `racksToPositions` | 16 tests | ✅ (new) |

### New racksToPositions Tests
- Empty array handling
- Single rack positioning (padding, dual-view width, height)
- Multiple rack positioning (side-by-side, sorting, vertical alignment)
- Edge cases (1U racks, 100U racks, same position, non-mutating)
- Position calculation accuracy (consistency, positive coords, no overlaps)

## Test Plan
- [x] All 32 canvas-utils tests pass
- [x] Full test suite passes (2073 tests)
- [x] Build succeeds
- [x] Lint passes

## Note
Issue #36 mentioned functions like `fitAllToView`, `calculateBoundingBox`, etc. that don't exist. The actual module exports:
- `calculateRacksBoundingBox` (was tested)
- `calculateFitAll` (was tested)
- `racksToPositions` (now tested)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)