### PR TITLE
chore: standardize form label capitalisation to Title Case (#15)

### DIFF
--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -456,11 +456,9 @@
 	}
 
 	.form-group label {
-		font-size: var(--font-size-sm);
-		font-weight: 600;
-		color: var(--colour-text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.5px;
+		font-size: var(--font-size-base);
+		font-weight: var(--font-weight-medium);
+		color: var(--colour-text);
 	}
 
 	.form-group input {
@@ -675,11 +673,9 @@
 	}
 
 	.face-selector legend {
-		font-size: var(--font-size-sm);
-		font-weight: 600;
-		color: var(--colour-text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.5px;
+		font-size: var(--font-size-base);
+		font-weight: var(--font-weight-medium);
+		color: var(--colour-text);
 		padding: 0 4px;
 	}
 


### PR DESCRIPTION
## Summary
- Standardize form label capitalisation to Title Case across the application
- Maintain uppercase styling for section headers/categories (ToolbarDrawer, DevicePalette, HelpPanel, Rack view labels)

## Changes
- `src/lib/components/EditPanel.svelte`: Remove `text-transform: uppercase` from form labels
  - `.form-group label`: Now uses Title Case with design tokens
  - `.face-selector legend`: Now uses Title Case with design tokens

## Design Decision
Following the recommendation in the issue comment:
- **Title Case** for form labels (modern convention, consistent with AddDeviceForm and NewRackForm)
- **Uppercase** for section headers/categories only

## Test Plan
- [x] Lint passes (`npm run lint`)
- [x] All 2040 tests pass (`npm run test:run`)
- [x] Build succeeds (`npm run build`)
- [ ] Visual inspection recommended

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)