### PR TITLE
fix: add mounting holes to both rack rails (#17)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -417,11 +417,16 @@
 		<!-- Rail mounting holes (3 per U on each rail) - rendered first so labels appear on top -->
 		{#each Array(rack.height).fill(null) as _hole, i (i)}
 			{@const baseY = i * U_HEIGHT + RACK_PADDING + RAIL_WIDTH + 4}
-			{@const holeX = RACK_WIDTH - RAIL_WIDTH / 2 - 1.5}
-			<!-- Right rail holes only - left rail has labels -->
-			<rect x={holeX} y={baseY - 2} width="3" height="4" rx="0.5" class="rack-hole" />
-			<rect x={holeX} y={baseY + 5} width="3" height="4" rx="0.5" class="rack-hole" />
-			<rect x={holeX} y={baseY + 12} width="3" height="4" rx="0.5" class="rack-hole" />
+			{@const leftHoleX = RAIL_WIDTH / 2 - 1.5}
+			{@const rightHoleX = RACK_WIDTH - RAIL_WIDTH / 2 - 1.5}
+			<!-- Left rail holes (behind U labels) -->
+			<rect x={leftHoleX} y={baseY - 2} width="3" height="4" rx="0.5" class="rack-hole" />
+			<rect x={leftHoleX} y={baseY + 5} width="3" height="4" rx="0.5" class="rack-hole" />
+			<rect x={leftHoleX} y={baseY + 12} width="3" height="4" rx="0.5" class="rack-hole" />
+			<!-- Right rail holes -->
+			<rect x={rightHoleX} y={baseY - 2} width="3" height="4" rx="0.5" class="rack-hole" />
+			<rect x={rightHoleX} y={baseY + 5} width="3" height="4" rx="0.5" class="rack-hole" />
+			<rect x={rightHoleX} y={baseY + 12} width="3" height="4" rx="0.5" class="rack-hole" />
 		{/each}
 
 		<!-- U labels (always on left rail) -->


### PR DESCRIPTION
## Summary
- Add mounting holes to left rail (currently only on right rail)
- Maintain U label visibility by rendering holes first (SVG z-order)

## Changes
- `src/lib/components/Rack.svelte`: Add left rail mounting holes
  - 3 holes per U on both rails (6 total per U)
  - Left holes render behind U labels

## Design Solution
The issue noted that U marker visibility must be maintained. Solution:
- SVG elements render in document order (earlier = behind)
- Mounting holes render before U labels
- Labels naturally overlay holes, remaining fully visible

## Test Plan
- [x] Lint passes (`npm run lint`)
- [x] All 2040 tests pass (`npm run test:run`)
- [x] Build succeeds (`npm run build`)
- [ ] Visual inspection recommended

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)