### PR TITLE
fix: resolve vite-plugin-svelte build warnings (#122)

### DIFF
--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -298,7 +298,7 @@
 					onblur={handleNotesBlur}
 					rows="4"
 					placeholder="Add notes about this rack..."
-				/>
+				></textarea>
 			</div>
 
 			<div class="actions">
@@ -442,7 +442,7 @@
 					onblur={handleDeviceNotesBlur}
 					rows="4"
 					placeholder="Add notes about this device placement..."
-				/>
+				></textarea>
 			</div>
 
 			<div class="actions">
@@ -643,21 +643,6 @@
 
 	.display-name-display:hover .edit-icon {
 		opacity: 1;
-	}
-
-	.display-name-input {
-		width: 100%;
-		padding: var(--space-2) var(--space-3);
-		font-size: var(--font-size-base);
-		border: 1px solid var(--colour-selection);
-		border-radius: var(--radius-sm);
-		background: var(--colour-bg);
-		color: var(--colour-text);
-		outline: none;
-	}
-
-	.display-name-input:focus {
-		box-shadow: var(--glow-pink-sm);
 	}
 
 	.notes-section {


### PR DESCRIPTION
## Summary
- Fix self-closing textarea tags to use explicit closing tags (2 instances)
- Remove unused `.display-name-input` and `.display-name-input:focus` CSS selectors

## Files Changed
- `src/lib/components/EditPanel.svelte`: Fixed textarea syntax and removed dead CSS

## Test Plan
- [x] `npm run build` produces no vite-plugin-svelte warnings
- [x] All EditPanel tests pass
- [x] Lint passes

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)