### PR TITLE
feat: add GitHub quick links for bug reports and feature requests (#121)

### DIFF
--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -79,6 +79,17 @@
 
 	const GITHUB_URL = 'https://github.com/rackarr/rackarr';
 
+	// Pre-filled issue URLs
+	const bugReportUrl = $derived(() => {
+		const params = new URLSearchParams({
+			template: 'bug-report.yml',
+			browser: `Rackarr v${VERSION} on ${userAgent}`
+		});
+		return `${GITHUB_URL}/issues/new?${params.toString()}`;
+	});
+
+	const featureRequestUrl = `${GITHUB_URL}/issues/new?template=feature-request.yml`;
+
 	function handleClose() {
 		onclose?.();
 	}
@@ -101,7 +112,7 @@
 
 <Dialog {open} title="About" width="600px" onclose={handleClose}>
 	<div class="about-content">
-		<!-- Header: Logo + Version + GitHub -->
+		<!-- Header: Logo + Version -->
 		<header class="about-header">
 			<div class="brand-row">
 				<LogoLockup size={48} />
@@ -127,20 +138,6 @@
 					</svg>
 				</button>
 			</div>
-			<a
-				href={GITHUB_URL}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="github-link"
-				title="View on GitHub"
-			>
-				<svg viewBox="0 0 24 24" width="24" height="24" aria-label="GitHub">
-					<path
-						fill="currentColor"
-						d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z"
-					/>
-				</svg>
-			</a>
 		</header>
 
 		<!-- Debug info (expandable) -->
@@ -177,6 +174,43 @@
 			</section>
 		{/each}
 
+		<!-- Quick links -->
+		<div class="quick-links">
+			<a
+				href={GITHUB_URL}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="quick-link"
+			>
+				<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+					<path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+				</svg>
+				Project
+			</a>
+			<a
+				href={bugReportUrl()}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="quick-link"
+			>
+				<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+					<path fill="currentColor" d="M4.72.22a.75.75 0 0 1 1.06 0l1 1a.75.75 0 0 1 0 1.06l-.22.22.439.44a5.02 5.02 0 0 1 2.022 0l.439-.44-.22-.22a.75.75 0 1 1 1.06-1.06l1 1a.75.75 0 0 1 0 1.06l-.22.22c.224.264.42.554.583.862L13 4.75a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-.75.75h-1.173a5.013 5.013 0 0 1 0 1.498H13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-.75.75h-1.341a4.997 4.997 0 0 1-.583.862l.22.22a.75.75 0 1 1-1.06 1.06l-1-1a.75.75 0 0 1 0-1.06l.22-.22a4.96 4.96 0 0 1-.439-.44 5.02 5.02 0 0 1-2.022 0l-.44.44.221.22a.75.75 0 1 1-1.06 1.06l-1-1a.75.75 0 0 1 0-1.06l.22-.22a4.997 4.997 0 0 1-.583-.862H3a.75.75 0 0 1-.75-.75v-1.5a.75.75 0 0 1 .75-.75h1.173a5.013 5.013 0 0 1 0-1.498H3a.75.75 0 0 1-.75-.75v-1.5A.75.75 0 0 1 3 4.75h1.341c.163-.308.359-.598.583-.862l-.22-.22a.75.75 0 0 1 0-1.06l1-1Zm2.78 5.53a3.5 3.5 0 1 0 5 5 3.5 3.5 0 0 0-5-5Z"/>
+				</svg>
+				Report Bug
+			</a>
+			<a
+				href={featureRequestUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="quick-link"
+			>
+				<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+					<path fill="currentColor" d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm7.25-3.25v2.5h2.5a.75.75 0 0 1 0 1.5h-2.5v2.5a.75.75 0 0 1-1.5 0v-2.5h-2.5a.75.75 0 0 1 0-1.5h2.5v-2.5a.75.75 0 0 1 1.5 0Z"/>
+				</svg>
+				Request Feature
+			</a>
+		</div>
+
 		<p class="made-in">Made in Canada 🇨🇦 with ❤️</p>
 	</div>
 </Dialog>
@@ -188,10 +222,9 @@
 		gap: var(--space-4);
 	}
 
-	/* Header row: Logo + Version + GitHub */
+	/* Header row: Logo + Version */
 	.about-header {
 		display: flex;
-		justify-content: space-between;
 		align-items: center;
 		padding-bottom: var(--space-3);
 		border-bottom: 1px solid var(--colour-border);
@@ -230,21 +263,6 @@
 
 	.chevron-icon.expanded {
 		transform: rotate(180deg);
-	}
-
-	.github-link {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		color: var(--colour-text-muted);
-		transition:
-			color 0.15s ease,
-			transform 0.15s ease;
-	}
-
-	.github-link:hover {
-		color: var(--colour-text);
-		transform: scale(1.1);
 	}
 
 	/* Debug info panel */
@@ -332,12 +350,50 @@
 		color: var(--colour-text-muted);
 	}
 
+	/* Quick links */
+	.quick-links {
+		display: flex;
+		gap: var(--space-3);
+		justify-content: center;
+		padding-top: var(--space-3);
+		border-top: 1px solid var(--colour-border);
+	}
+
+	.quick-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-2);
+		flex: 1;
+		padding: var(--space-2) var(--space-3);
+		font-size: var(--font-size-sm);
+		color: var(--colour-text-muted);
+		text-decoration: none;
+		background: var(--colour-surface);
+		border: 1px solid var(--colour-border);
+		border-radius: var(--radius-sm);
+		transition:
+			color 0.15s ease,
+			border-color 0.15s ease,
+			background 0.15s ease;
+	}
+
+	.quick-link:hover {
+		color: var(--colour-text);
+		border-color: var(--colour-selection);
+		background: var(--colour-surface-hover);
+	}
+
+	.quick-link:focus-visible {
+		outline: 2px solid var(--colour-selection);
+		outline-offset: 2px;
+	}
+
 	.made-in {
 		margin: 0;
 		padding-top: var(--space-3);
 		font-size: var(--font-size-sm);
 		color: var(--colour-text-muted);
 		text-align: center;
-		border-top: 1px solid var(--colour-border);
 	}
 </style>

--- a/src/tests/HelpPanel.test.ts
+++ b/src/tests/HelpPanel.test.ts
@@ -57,32 +57,75 @@ describe('HelpPanel', () => {
 		});
 	});
 
-	describe('Links', () => {
-		it('shows GitHub link icon', () => {
+	describe('Quick Links', () => {
+		it('shows Project link with GitHub logo', () => {
 			render(HelpPanel, { props: { open: true } });
 
-			expect(screen.getByRole('link', { name: /github/i })).toBeInTheDocument();
+			const projectLink = screen.getByRole('link', { name: /project/i });
+			expect(projectLink).toBeInTheDocument();
 		});
 
-		it('GitHub link points to correct repository', () => {
+		it('Project link points to GitHub repository', () => {
 			render(HelpPanel, { props: { open: true } });
 
-			const githubLink = screen.getByRole('link', { name: /github/i });
-			expect(githubLink.getAttribute('href')).toBe('https://github.com/rackarr/rackarr');
+			const projectLink = screen.getByRole('link', { name: /project/i });
+			expect(projectLink.getAttribute('href')).toBe('https://github.com/rackarr/rackarr');
 		});
 
-		it('GitHub link opens in new tab', () => {
+		it('shows Report Bug link', () => {
 			render(HelpPanel, { props: { open: true } });
 
-			const githubLink = screen.getByRole('link', { name: /github/i });
-			expect(githubLink.getAttribute('target')).toBe('_blank');
+			const bugLink = screen.getByRole('link', { name: /report bug/i });
+			expect(bugLink).toBeInTheDocument();
 		});
 
-		it('GitHub link has rel="noopener noreferrer" for security', () => {
+		it('Report Bug link pre-fills browser info', () => {
 			render(HelpPanel, { props: { open: true } });
 
-			const githubLink = screen.getByRole('link', { name: /github/i });
-			expect(githubLink.getAttribute('rel')).toContain('noopener');
+			const bugLink = screen.getByRole('link', { name: /report bug/i });
+			const href = bugLink.getAttribute('href');
+			expect(href).toContain('template=bug-report.yml');
+			expect(href).toContain('browser=');
+			// URLSearchParams encodes spaces as + not %20
+			expect(href).toContain(`Rackarr+v${VERSION}`);
+		});
+
+		it('shows Request Feature link', () => {
+			render(HelpPanel, { props: { open: true } });
+
+			const featureLink = screen.getByRole('link', { name: /request feature/i });
+			expect(featureLink).toBeInTheDocument();
+		});
+
+		it('Request Feature link uses correct template', () => {
+			render(HelpPanel, { props: { open: true } });
+
+			const featureLink = screen.getByRole('link', { name: /request feature/i });
+			expect(featureLink.getAttribute('href')).toContain('template=feature-request.yml');
+		});
+
+		it('all quick links open in new tab', () => {
+			render(HelpPanel, { props: { open: true } });
+
+			const projectLink = screen.getByRole('link', { name: /project/i });
+			const bugLink = screen.getByRole('link', { name: /report bug/i });
+			const featureLink = screen.getByRole('link', { name: /request feature/i });
+
+			expect(projectLink.getAttribute('target')).toBe('_blank');
+			expect(bugLink.getAttribute('target')).toBe('_blank');
+			expect(featureLink.getAttribute('target')).toBe('_blank');
+		});
+
+		it('all quick links have rel="noopener noreferrer" for security', () => {
+			render(HelpPanel, { props: { open: true } });
+
+			const projectLink = screen.getByRole('link', { name: /project/i });
+			const bugLink = screen.getByRole('link', { name: /report bug/i });
+			const featureLink = screen.getByRole('link', { name: /request feature/i });
+
+			expect(projectLink.getAttribute('rel')).toContain('noopener');
+			expect(bugLink.getAttribute('rel')).toContain('noopener');
+			expect(featureLink.getAttribute('rel')).toContain('noopener');
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Add three quick links at the bottom of the About/Help panel:
  - **Project** - GitHub repository link with GitHub logo
  - **Report Bug** - Opens bug report template with pre-filled version and browser info
  - **Request Feature** - Opens feature request template
- Links are styled consistently with equal widths
- Moved GitHub link from header to the quick links section

## Files Changed
- `src/lib/components/HelpPanel.svelte`: Added quick links section, removed header GitHub icon
- `src/tests/HelpPanel.test.ts`: Updated tests for new link structure

## Test Plan
- [x] Project link shows GitHub logo and links to repository
- [x] Report Bug link pre-fills browser info in URL
- [x] Request Feature link uses correct template
- [x] All links open in new tab with security attributes
- [x] All HelpPanel tests pass

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)