### PR TITLE
feat: add optional QR code to exports (#101)

### DIFF
--- a/src/lib/components/ExportDialog.svelte
+++ b/src/lib/components/ExportDialog.svelte
@@ -29,6 +29,7 @@
 		selectedRackId: string | null;
 		isExporting?: boolean;
 		exportMessage?: string;
+		qrCodeDataUrl?: string;
 		onexport?: (event: CustomEvent<ExportOptions>) => void;
 		oncancel?: () => void;
 	}
@@ -43,6 +44,7 @@
 		selectedRackId: _selectedRackId,
 		isExporting = false,
 		exportMessage = 'Exporting...',
+		qrCodeDataUrl,
 		onexport,
 		oncancel
 	}: Props = $props();
@@ -53,12 +55,16 @@
 	let background = $state<ExportBackground>('dark');
 	let exportView = $state<ExportView>('both');
 	let transparent = $state(false);
+	let includeQR = $state(false);
 
 	// Computed: Is CSV format (data export - no image options)
 	const isCSV = $derived(format === 'csv');
 
 	// Computed: Can select transparent background (PNG and SVG only)
 	const canSelectTransparent = $derived(format === 'svg' || format === 'png');
+
+	// Computed: Can include QR code (when QR code data URL is available and not CSV)
+	const canIncludeQR = $derived(!isCSV && !!qrCodeDataUrl);
 
 	// Computed: Can export (has racks)
 	const canExport = $derived(racks.length > 0);
@@ -128,7 +134,9 @@
 			includeNames: true,
 			includeLegend,
 			background: effectiveBackground,
-			exportView
+			exportView,
+			includeQR: canIncludeQR ? includeQR : false,
+			qrCodeDataUrl: canIncludeQR && includeQR ? qrCodeDataUrl : undefined
 		};
 		onexport?.(new CustomEvent('export', { detail: options }));
 	}
@@ -201,6 +209,15 @@
 					<label>
 						<input type="checkbox" bind:checked={transparent} />
 						Transparent background
+					</label>
+				</div>
+			{/if}
+
+			{#if canIncludeQR}
+				<div class="form-group checkbox-group">
+					<label>
+						<input type="checkbox" bind:checked={includeQR} />
+						Include sharing QR code
 					</label>
 				</div>
 			{/if}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -400,4 +400,8 @@ export interface ExportOptions {
 	exportView?: ExportView;
 	/** Display mode */
 	displayMode?: DisplayMode;
+	/** Include sharing QR code in export */
+	includeQR?: boolean;
+	/** Pre-generated QR code as PNG data URL (required when includeQR is true) */
+	qrCodeDataUrl?: string;
 }


### PR DESCRIPTION
## Summary
- Add option to include a sharing QR code in PNG, JPEG, SVG, and PDF exports
- QR code encodes the shareable URL so recipients can scan and open the layout in Rackarr
- Checkbox is unchecked by default (disabled by user request)
- Hidden when layout is too large for QR capacity or for CSV exports

## Implementation
- `ExportOptions` type extended with `includeQR` and `qrCodeDataUrl` fields
- ExportDialog displays checkbox when QR code is available
- `generateExportSVG` renders QR code in bottom-right corner at 150px
- White background ensures visibility on all export backgrounds
- QR code pre-generated when export dialog opens

## Files Changed
- `src/lib/types/index.ts`: Add QR export options
- `src/lib/utils/export.ts`: QR code rendering in SVG
- `src/lib/components/ExportDialog.svelte`: QR checkbox UI
- `src/App.svelte`: Generate QR code on export dialog open
- `src/tests/export.test.ts`: QR code export tests
- `src/tests/ExportDialog.test.ts`: QR checkbox UI tests

## Test plan
- [x] QR checkbox appears when qrCodeDataUrl is provided
- [x] QR checkbox defaults to unchecked
- [x] QR code renders in bottom-right corner of export
- [x] QR code has white background for contrast
- [x] QR code hidden for CSV format
- [x] Export works without QR code when unchecked
- [x] Lint passes
- [x] Build succeeds

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)