### PR TITLE
feat: add image availability indicator to device library (#120)

### DIFF
--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -7,6 +7,7 @@
 	import type { DeviceType } from '$lib/types';
 	import IconGrip from './icons/IconGrip.svelte';
 	import CategoryIcon from './CategoryIcon.svelte';
+	import ImageIndicator from './ImageIndicator.svelte';
 	import { createPaletteDragData, serializeDragData } from '$lib/utils/dragdrop';
 	import { highlightMatch } from '$lib/utils/searchHighlight';
 
@@ -84,6 +85,9 @@
 			{/if}
 		{/each}
 	</span>
+	{#if device.front_image || device.rear_image}
+		<ImageIndicator front={device.front_image} rear={device.rear_image} size={14} />
+	{/if}
 	<span class="device-height">{device.u_height}U</span>
 </div>
 

--- a/src/lib/components/ImageIndicator.svelte
+++ b/src/lib/components/ImageIndicator.svelte
@@ -1,0 +1,79 @@
+<!--
+	ImageIndicator Component
+	Shows device image availability with a split-fill visual
+	Left half = front image, Right half = rear image
+-->
+<script lang="ts">
+	interface Props {
+		front?: boolean;
+		rear?: boolean;
+		size?: number;
+	}
+
+	let { front = false, rear = false, size = 14 }: Props = $props();
+
+	// Don't render if no images available
+	const hasImages = $derived(front || rear);
+
+	// Determine fill states
+	const leftFill = $derived(front ? 'currentColor' : 'none');
+	const rightFill = $derived(rear ? 'currentColor' : 'none');
+
+	// Title for accessibility
+	const title = $derived(
+		front && rear
+			? 'Front and rear images available'
+			: front
+				? 'Front image available'
+				: 'Rear image available'
+	);
+</script>
+
+{#if hasImages}
+	<span class="image-indicator" aria-hidden="true">
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 16 16"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<title>{title}</title>
+			<!-- Left half (front) -->
+			<rect
+				class="indicator-left"
+				x="1"
+				y="3"
+				width="6"
+				height="10"
+				rx="1"
+				fill={leftFill}
+				stroke="currentColor"
+				stroke-width="1.5"
+			/>
+			<!-- Right half (rear) -->
+			<rect
+				class="indicator-right"
+				x="9"
+				y="3"
+				width="6"
+				height="10"
+				rx="1"
+				fill={rightFill}
+				stroke="currentColor"
+				stroke-width="1.5"
+			/>
+		</svg>
+	</span>
+{/if}
+
+<style>
+	.image-indicator {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--colour-text-muted);
+		flex-shrink: 0;
+	}
+</style>

--- a/src/tests/ImageIndicator.test.ts
+++ b/src/tests/ImageIndicator.test.ts
@@ -1,0 +1,121 @@
+/**
+ * ImageIndicator Component Tests
+ * Tests for device image availability indicator
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import ImageIndicator from '$lib/components/ImageIndicator.svelte';
+
+describe('ImageIndicator', () => {
+	describe('Visibility', () => {
+		it('renders nothing when both front and rear are false', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: false, rear: false }
+			});
+			expect(container.querySelector('.image-indicator')).toBeNull();
+		});
+
+		it('renders indicator when front is true', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: true, rear: false }
+			});
+			expect(container.querySelector('.image-indicator')).toBeTruthy();
+		});
+
+		it('renders indicator when rear is true', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: false, rear: true }
+			});
+			expect(container.querySelector('.image-indicator')).toBeTruthy();
+		});
+
+		it('renders indicator when both are true', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: true, rear: true }
+			});
+			expect(container.querySelector('.image-indicator')).toBeTruthy();
+		});
+	});
+
+	describe('Visual States', () => {
+		it('shows front-only state with left half filled', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: true, rear: false }
+			});
+			const svg = container.querySelector('svg');
+			expect(svg).toBeTruthy();
+			// Left rect should be filled
+			const leftRect = svg?.querySelector('.indicator-left');
+			expect(leftRect?.getAttribute('fill')).not.toBe('none');
+			// Right rect should be empty (stroke only)
+			const rightRect = svg?.querySelector('.indicator-right');
+			expect(rightRect?.getAttribute('fill')).toBe('none');
+		});
+
+		it('shows rear-only state with right half filled', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: false, rear: true }
+			});
+			const svg = container.querySelector('svg');
+			expect(svg).toBeTruthy();
+			// Left rect should be empty
+			const leftRect = svg?.querySelector('.indicator-left');
+			expect(leftRect?.getAttribute('fill')).toBe('none');
+			// Right rect should be filled
+			const rightRect = svg?.querySelector('.indicator-right');
+			expect(rightRect?.getAttribute('fill')).not.toBe('none');
+		});
+
+		it('shows both state with full fill', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: true, rear: true }
+			});
+			const svg = container.querySelector('svg');
+			expect(svg).toBeTruthy();
+			// Both rects should be filled
+			const leftRect = svg?.querySelector('.indicator-left');
+			const rightRect = svg?.querySelector('.indicator-right');
+			expect(leftRect?.getAttribute('fill')).not.toBe('none');
+			expect(rightRect?.getAttribute('fill')).not.toBe('none');
+		});
+	});
+
+	describe('Size Prop', () => {
+		it('uses default size of 14 when not specified', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: true, rear: false }
+			});
+			const svg = container.querySelector('svg');
+			expect(svg?.getAttribute('width')).toBe('14');
+			expect(svg?.getAttribute('height')).toBe('14');
+		});
+
+		it('applies custom size when specified', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: true, rear: false, size: 20 }
+			});
+			const svg = container.querySelector('svg');
+			expect(svg?.getAttribute('width')).toBe('20');
+			expect(svg?.getAttribute('height')).toBe('20');
+		});
+	});
+
+	describe('Accessibility', () => {
+		it('has aria-hidden for decorative purposes', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: true, rear: true }
+			});
+			const svg = container.querySelector('svg');
+			expect(svg?.getAttribute('aria-hidden')).toBe('true');
+		});
+
+		it('has appropriate title for screen readers', () => {
+			const { container } = render(ImageIndicator, {
+				props: { front: true, rear: true }
+			});
+			const title = container.querySelector('title');
+			expect(title?.textContent).toContain('image');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Adds visual indicator showing which devices have images in the device library
- Uses split-fill icon design: left half = front image, right half = rear image
- Positioned between device name and U-height badge

## Files Changed
- `src/lib/components/ImageIndicator.svelte` (new) - Split-fill indicator component
- `src/lib/components/DevicePaletteItem.svelte` - Integrate indicator
- `src/tests/ImageIndicator.test.ts` (new) - 11 test cases

## Test Plan
- [x] Indicator hidden when device has no images
- [x] Left half filled for front-only images
- [x] Right half filled for rear-only images
- [x] Both halves filled for front+rear images
- [x] All tests pass (2313 total)
- [x] Build succeeds

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)