### PR TITLE
fix: use camera icon for image indicator

### DIFF
--- a/src/lib/components/ImageIndicator.svelte
+++ b/src/lib/components/ImageIndicator.svelte
@@ -1,6 +1,6 @@
 <!--
 	ImageIndicator Component
-	Shows device image availability with a split-fill visual
+	Shows device image availability with a camera icon
 	Left half = front image, Right half = rear image
 -->
 <script lang="ts">
@@ -40,29 +40,47 @@
 			aria-hidden="true"
 		>
 			<title>{title}</title>
-			<!-- Left half (front) -->
+			<!-- Camera body outline -->
 			<rect
-				class="indicator-left"
 				x="1"
-				y="3"
-				width="6"
+				y="4"
+				width="14"
 				height="10"
-				rx="1"
-				fill={leftFill}
+				rx="2"
+				fill="none"
 				stroke="currentColor"
 				stroke-width="1.5"
 			/>
-			<!-- Right half (rear) -->
+			<!-- Viewfinder bump -->
 			<rect
-				class="indicator-right"
-				x="9"
-				y="3"
+				x="5"
+				y="2"
 				width="6"
-				height="10"
+				height="3"
 				rx="1"
-				fill={rightFill}
+				fill="none"
 				stroke="currentColor"
 				stroke-width="1.5"
+			/>
+			<!-- Left half fill (front) -->
+			<rect
+				class="indicator-left"
+				x="2"
+				y="5"
+				width="6"
+				height="8"
+				rx="1"
+				fill={leftFill}
+			/>
+			<!-- Right half fill (rear) -->
+			<rect
+				class="indicator-right"
+				x="8"
+				y="5"
+				width="6"
+				height="8"
+				rx="1"
+				fill={rightFill}
 			/>
 		</svg>
 	</span>


### PR DESCRIPTION
## Summary
Replaces the abstract split-rectangle icon with a recognizable camera silhouette for the device image availability indicator.

## Changes
- Camera body outline with rounded corners
- Viewfinder bump on top for visual recognition
- Same split-fill behavior: left half = front, right half = rear

## Before/After
**Before:** Two vertical rectangles (looked like a book)
**After:** Camera silhouette with split-fill interior

## Test Plan
- [x] All 11 ImageIndicator tests pass
- [x] Lint passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)