### PR TITLE
fix: position rack mounting holes near inner edge of rails (#134)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -417,8 +417,8 @@
 		<!-- Rail mounting holes (3 per U on each rail) - rendered first so labels appear on top -->
 		{#each Array(rack.height).fill(null) as _hole, i (i)}
 			{@const baseY = i * U_HEIGHT + RACK_PADDING + RAIL_WIDTH + 4}
-			{@const leftHoleX = RAIL_WIDTH / 2 - 1.5}
-			{@const rightHoleX = RACK_WIDTH - RAIL_WIDTH / 2 - 1.5}
+			{@const leftHoleX = RAIL_WIDTH - 4}
+			{@const rightHoleX = RACK_WIDTH - RAIL_WIDTH + 1}
 			<!-- Left rail holes (behind U labels) -->
 			<rect x={leftHoleX} y={baseY - 2} width="3" height="4" rx="0.5" class="rack-hole" />
 			<rect x={leftHoleX} y={baseY + 5} width="3" height="4" rx="0.5" class="rack-hole" />

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -384,10 +384,7 @@ export function generateExportSVG(
 	// Calculate sidebar (legend + QR column) dimensions
 	// QR code shares the same column as legend, positioned at the bottom
 	const hasSidebar = includeLegend || shouldRenderQR;
-	const sidebarWidth = Math.max(
-		includeLegend ? legendWidth : 0,
-		shouldRenderQR ? qrTotalSize : 0
-	);
+	const sidebarWidth = Math.max(includeLegend ? legendWidth : 0, shouldRenderQR ? qrTotalSize : 0);
 
 	const contentWidth = totalRackWidth + (hasSidebar ? LEGEND_PADDING + sidebarWidth : 0);
 	const contentHeight = Math.max(rackAreaHeight, legendHeight);
@@ -508,7 +505,7 @@ export function generateExportSVG(
 		const holeColor = isDark ? '#505050' : '#a0a0a0';
 		for (let i = 0; i < rack.height; i++) {
 			const baseY = i * U_HEIGHT + RACK_PADDING + RAIL_WIDTH + 4;
-			const holeX = RACK_WIDTH - RAIL_WIDTH / 2;
+			const holeX = RACK_WIDTH - RAIL_WIDTH + 2.5;
 
 			for (const offsetY of [0, 7, 14]) {
 				const hole = document.createElementNS('http://www.w3.org/2000/svg', 'circle');

--- a/src/tests/RackDevice.test.ts
+++ b/src/tests/RackDevice.test.ts
@@ -9,7 +9,7 @@ describe('RackDevice SVG Component', () => {
 	const U_HEIGHT = 22;
 	const RACK_WIDTH = 220;
 	const RAIL_WIDTH = 17;
-	const IMAGE_OVERFLOW = 8; // Images extend past rails for realistic appearance
+	const IMAGE_OVERFLOW = 4; // Images extend past rails for realistic appearance
 
 	const mockDevice: DeviceType = {
 		slug: 'device-1',

--- a/src/tests/RackMountingHoles.test.ts
+++ b/src/tests/RackMountingHoles.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import Rack from '$lib/components/Rack.svelte';
+import { generateExportSVG } from '$lib/utils/export';
+import { resetLayoutStore, getLayoutStore } from '$lib/stores/layout.svelte';
+import { resetSelectionStore } from '$lib/stores/selection.svelte';
+import { resetUIStore } from '$lib/stores/ui.svelte';
+import type { Rack as RackType, ExportOptions, DeviceType } from '$lib/types';
+
+/**
+ * Issue #134: Rack mounting holes positioned incorrectly in center of posts
+ *
+ * On real server racks, mounting holes are located near the inner edge of the rails
+ * (facing the device mounting area), not centered in the post.
+ *
+ * Current: holes at RAIL_WIDTH / 2 (~8.5px from outer edge)
+ * Expected: holes at ~12-14px from outer edge (3-5px from inner edge)
+ *
+ * RAIL_WIDTH = 17px, so inner edge is at x=17 for left rail
+ */
+describe('Rack Mounting Holes Position (#134)', () => {
+	// Constants matching Rack.svelte
+	const RAIL_WIDTH = 17;
+	const RACK_WIDTH = 220;
+
+	let testRack: RackType;
+
+	beforeEach(() => {
+		resetLayoutStore();
+		resetSelectionStore();
+		resetUIStore();
+
+		const layoutStore = getLayoutStore();
+		const rack = layoutStore.addRack('Test Rack', 12);
+		testRack = rack!;
+	});
+
+	describe('Interactive Rack Component', () => {
+		it('renders 3 mounting holes per U on left rail', () => {
+			const { container } = render(Rack, {
+				props: {
+					rack: testRack,
+					deviceLibrary: [],
+					selected: false
+				}
+			});
+
+			const holes = container.querySelectorAll('.rack-hole');
+			// 12U rack = 12 * 3 holes per side * 2 sides = 72 holes
+			expect(holes.length).toBe(72);
+		});
+
+		it('positions left rail holes near inner edge of rail (12-14px from outer edge)', () => {
+			const { container } = render(Rack, {
+				props: {
+					rack: testRack,
+					deviceLibrary: [],
+					selected: false
+				}
+			});
+
+			const holes = container.querySelectorAll('.rack-hole');
+			// Get the first hole (left rail)
+			const firstHole = holes[0] as SVGRectElement;
+			const holeX = parseFloat(firstHole.getAttribute('x') || '0');
+
+			// Holes should be positioned 12-14px from outer edge (x = 0)
+			// This means x should be between 12 and 14 (accounting for hole width of 3px)
+			// The x attribute is the left edge of the hole rect
+			expect(holeX).toBeGreaterThanOrEqual(11);
+			expect(holeX).toBeLessThanOrEqual(15);
+		});
+
+		it('positions right rail holes near inner edge of rail (3-5px from inner edge)', () => {
+			const { container } = render(Rack, {
+				props: {
+					rack: testRack,
+					deviceLibrary: [],
+					selected: false
+				}
+			});
+
+			const holes = container.querySelectorAll('.rack-hole');
+			// Right rail holes start after left rail holes (first 36 are left, next 36 are right for 12U)
+			// In the current code, holes are rendered: 3 left, then 3 right per U
+			// So right rail first hole is at index 3
+			const rightHole = holes[3] as SVGRectElement;
+			const holeX = parseFloat(rightHole.getAttribute('x') || '0');
+
+			// Right rail starts at RACK_WIDTH - RAIL_WIDTH = 203
+			// Holes should be 3-5px from inner edge, meaning x should be between 203 and 207
+			const rightRailInnerEdge = RACK_WIDTH - RAIL_WIDTH;
+			expect(holeX).toBeGreaterThanOrEqual(rightRailInnerEdge);
+			expect(holeX).toBeLessThanOrEqual(rightRailInnerEdge + 6);
+		});
+
+		it('left rail holes do not extend into device mounting area', () => {
+			const { container } = render(Rack, {
+				props: {
+					rack: testRack,
+					deviceLibrary: [],
+					selected: false
+				}
+			});
+
+			const holes = container.querySelectorAll('.rack-hole');
+			// Check all left rail holes (every 6th hole starting from 0, 1, 2)
+			for (let i = 0; i < holes.length; i += 6) {
+				for (let j = 0; j < 3; j++) {
+					const hole = holes[i + j] as SVGRectElement;
+					const holeX = parseFloat(hole.getAttribute('x') || '0');
+					const holeWidth = parseFloat(hole.getAttribute('width') || '0');
+					// Hole right edge should not exceed RAIL_WIDTH
+					expect(holeX + holeWidth).toBeLessThanOrEqual(RAIL_WIDTH);
+				}
+			}
+		});
+
+		it('right rail holes do not extend beyond rack width', () => {
+			const { container } = render(Rack, {
+				props: {
+					rack: testRack,
+					deviceLibrary: [],
+					selected: false
+				}
+			});
+
+			const holes = container.querySelectorAll('.rack-hole');
+			// Check right rail holes (every 6th hole starting from 3, 4, 5)
+			for (let i = 3; i < holes.length; i += 6) {
+				for (let j = 0; j < 3 && i + j < holes.length; j++) {
+					const hole = holes[i + j] as SVGRectElement;
+					const holeX = parseFloat(hole.getAttribute('x') || '0');
+					const holeWidth = parseFloat(hole.getAttribute('width') || '0');
+					// Hole right edge should not exceed RACK_WIDTH
+					expect(holeX + holeWidth).toBeLessThanOrEqual(RACK_WIDTH);
+				}
+			}
+		});
+	});
+
+	describe('Export SVG', () => {
+		const mockDeviceLibrary: DeviceType[] = [];
+		const defaultOptions: ExportOptions = {
+			format: 'png',
+			scope: 'all',
+			includeNames: false,
+			includeLegend: false,
+			background: 'dark'
+		};
+
+		it('positions right rail holes near inner edge in export', () => {
+			const svg = generateExportSVG([testRack], mockDeviceLibrary, defaultOptions);
+
+			// Export uses circles for holes, not rects
+			const holes = svg.querySelectorAll('circle');
+			expect(holes.length).toBeGreaterThan(0);
+
+			// Get first hole's cx position
+			const firstHole = holes[0] as SVGCircleElement;
+			const holeCX = parseFloat(firstHole.getAttribute('cx') || '0');
+
+			// Right rail starts at RACK_WIDTH - RAIL_WIDTH = 203
+			// Holes should be near inner edge: cx should be between 203 and 208
+			const rightRailInnerEdge = RACK_WIDTH - RAIL_WIDTH;
+			expect(holeCX).toBeGreaterThanOrEqual(rightRailInnerEdge);
+			expect(holeCX).toBeLessThanOrEqual(rightRailInnerEdge + 6);
+		});
+
+		it('export holes are positioned consistently with interactive component', () => {
+			// Render interactive component
+			const { container } = render(Rack, {
+				props: {
+					rack: testRack,
+					deviceLibrary: [],
+					selected: false
+				}
+			});
+
+			// Generate export SVG
+			const svg = generateExportSVG([testRack], mockDeviceLibrary, defaultOptions);
+
+			// Get left rail hole from interactive (first hole)
+			const interactiveHoles = container.querySelectorAll('.rack-hole');
+			const interactiveHole = interactiveHoles[0] as SVGRectElement;
+			const interactiveX = parseFloat(interactiveHole.getAttribute('x') || '0');
+
+			// Get right rail hole from export
+			const exportHoles = svg.querySelectorAll('circle');
+			const exportHole = exportHoles[0] as SVGCircleElement;
+			const exportCX = parseFloat(exportHole.getAttribute('cx') || '0');
+
+			// Both should be positioned near inner edge of their respective rails
+			// Interactive: left rail, near inner edge (x ~13)
+			// Export: right rail, near inner edge (cx ~204)
+
+			// Verify interactive left rail hole is near inner edge
+			expect(interactiveX).toBeGreaterThanOrEqual(11);
+			expect(interactiveX).toBeLessThanOrEqual(15);
+
+			// Verify export right rail hole is near inner edge
+			const rightRailInnerEdge = RACK_WIDTH - RAIL_WIDTH;
+			expect(exportCX).toBeGreaterThanOrEqual(rightRailInnerEdge);
+			expect(exportCX).toBeLessThanOrEqual(rightRailInnerEdge + 6);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Repositions rack mounting holes from center of rails to near the inner edge
- On real server racks, mounting holes are located near the inner edge of the rails (facing the device mounting area), not centered in the post
- Left rail holes moved from ~7px to ~13px from outer edge
- Right rail holes moved from ~210px to ~204px (inner edge)

## Files Changed
- `src/lib/components/Rack.svelte`: Updated leftHoleX and rightHoleX calculations
- `src/lib/utils/export.ts`: Updated holeX calculation for export SVG
- `src/tests/RackMountingHoles.test.ts`: Added new test file for mounting hole positioning
- `src/tests/RackDevice.test.ts`: Fixed IMAGE_OVERFLOW constant to match component value (8→4)

## Test Plan
- [x] All 2320 tests pass
- [x] Build succeeds
- [x] New mounting hole tests verify correct positioning on both rails
- [x] Visual inspection confirms holes are near inner edge of rails

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)