### PR TITLE
feat: improve toolbar logo button UX with rainbow hover

### DIFF
--- a/src/lib/components/LogoLockup.svelte
+++ b/src/lib/components/LogoLockup.svelte
@@ -16,10 +16,13 @@
 
 	let { size = 36, celebrate = false, partyMode = false, showcase = false }: Props = $props();
 
+	// Hover state for rainbow animation
+	let hovering = $state(false);
+
 	// Calculate proportional title height (logo should be slightly taller)
 	const titleHeight = $derived(size * 1.2);
 
-	// Determine which gradient to use based on state
+	// Determine which gradient to use based on state (priority order)
 	const gradientId = $derived(
 		partyMode
 			? 'url(#lockup-party)'
@@ -27,11 +30,18 @@
 				? 'url(#lockup-celebrate)'
 				: showcase
 					? 'url(#lockup-showcase)'
-					: null
+					: hovering
+						? 'url(#lockup-rainbow)'
+						: null
 	);
 </script>
 
-<div class="logo-lockup">
+<div
+	class="logo-lockup"
+	onmouseenter={() => (hovering = true)}
+	onmouseleave={() => (hovering = false)}
+	role="presentation"
+>
 	<!-- Hidden SVG for gradient definitions -->
 	<svg width="0" height="0" style="position: absolute;" aria-hidden="true">
 		<defs>
@@ -178,6 +188,7 @@
 		class:logo-mark--celebrate={celebrate}
 		class:logo-mark--party={partyMode}
 		class:logo-mark--showcase={showcase}
+		class:logo-mark--hover={hovering && !partyMode && !celebrate && !showcase}
 		viewBox="0 0 32 32"
 		width={size}
 		height={size}
@@ -194,6 +205,7 @@
 		class:logo-title--celebrate={celebrate}
 		class:logo-title--party={partyMode}
 		class:logo-title--showcase={showcase}
+		class:logo-title--hover={hovering && !partyMode && !celebrate && !showcase}
 		viewBox="0 0 200 50"
 		height={titleHeight}
 		role="img"
@@ -269,6 +281,17 @@
 	.logo-mark--showcase,
 	.logo-title--showcase {
 		filter: drop-shadow(0 0 16px rgba(189, 147, 249, 0.4));
+	}
+
+	/* Hover state: 6s rainbow cycle */
+	.logo-mark--hover,
+	.logo-title--hover text {
+		fill: var(--active-gradient, url(#lockup-rainbow)) !important;
+	}
+
+	.logo-mark--hover,
+	.logo-title--hover {
+		filter: drop-shadow(0 0 12px rgba(189, 147, 249, 0.4));
 	}
 
 	/* Respect reduced motion preference */

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -314,8 +314,7 @@
 	</div>
 
 	<!-- Right section: Empty (previously held theme toggle) -->
-	<div class="toolbar-section toolbar-right">
-	</div>
+	<div class="toolbar-section toolbar-right"></div>
 </header>
 
 <!-- Toolbar Drawer (hamburger menu) -->
@@ -406,10 +405,12 @@
 	/* Clickable brand (opens About in non-hamburger mode) */
 	.toolbar-brand--clickable {
 		cursor: pointer;
+		border: 1px solid var(--colour-border);
 	}
 
 	.toolbar-brand--clickable:hover {
 		background: var(--colour-surface-hover);
+		border-color: var(--colour-border-hover, var(--colour-border));
 	}
 
 	.toolbar-brand--clickable:focus-visible {

--- a/src/tests/LogoLockup.test.ts
+++ b/src/tests/LogoLockup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, fireEvent } from '@testing-library/svelte';
 import LogoLockup from '$lib/components/LogoLockup.svelte';
 
 describe('LogoLockup', () => {
@@ -142,6 +142,76 @@ describe('LogoLockup', () => {
 
 			expect(logoMark).toHaveStyle('--active-gradient: url(#lockup-party)');
 			expect(logoMark).toHaveClass('logo-mark--party');
+		});
+	});
+
+	describe('Hover State', () => {
+		it('applies hover class on mouseenter', async () => {
+			const { container } = render(LogoLockup);
+			const lockup = container.querySelector('.logo-lockup')!;
+			const logoMark = container.querySelector('.logo-mark');
+
+			await fireEvent.mouseEnter(lockup);
+
+			expect(logoMark).toHaveClass('logo-mark--hover');
+		});
+
+		it('removes hover class on mouseleave', async () => {
+			const { container } = render(LogoLockup);
+			const lockup = container.querySelector('.logo-lockup')!;
+			const logoMark = container.querySelector('.logo-mark');
+
+			await fireEvent.mouseEnter(lockup);
+			expect(logoMark).toHaveClass('logo-mark--hover');
+
+			await fireEvent.mouseLeave(lockup);
+			expect(logoMark).not.toHaveClass('logo-mark--hover');
+		});
+
+		it('sets rainbow gradient on hover', async () => {
+			const { container } = render(LogoLockup);
+			const lockup = container.querySelector('.logo-lockup')!;
+			const logoMark = container.querySelector('.logo-mark');
+
+			await fireEvent.mouseEnter(lockup);
+
+			expect(logoMark).toHaveStyle('--active-gradient: url(#lockup-rainbow)');
+		});
+
+		it('hover does not apply when partyMode is active', async () => {
+			const { container } = render(LogoLockup, { props: { partyMode: true } });
+			const lockup = container.querySelector('.logo-lockup')!;
+			const logoMark = container.querySelector('.logo-mark');
+
+			await fireEvent.mouseEnter(lockup);
+
+			// Party mode takes precedence, hover class should not be applied
+			expect(logoMark).not.toHaveClass('logo-mark--hover');
+			expect(logoMark).toHaveClass('logo-mark--party');
+		});
+
+		it('hover does not apply when celebrate is active', async () => {
+			const { container } = render(LogoLockup, { props: { celebrate: true } });
+			const lockup = container.querySelector('.logo-lockup')!;
+			const logoMark = container.querySelector('.logo-mark');
+
+			await fireEvent.mouseEnter(lockup);
+
+			// Celebrate takes precedence, hover class should not be applied
+			expect(logoMark).not.toHaveClass('logo-mark--hover');
+			expect(logoMark).toHaveClass('logo-mark--celebrate');
+		});
+
+		it('hover does not apply when showcase is active', async () => {
+			const { container } = render(LogoLockup, { props: { showcase: true } });
+			const lockup = container.querySelector('.logo-lockup')!;
+			const logoMark = container.querySelector('.logo-mark');
+
+			await fireEvent.mouseEnter(lockup);
+
+			// Showcase takes precedence, hover class should not be applied
+			expect(logoMark).not.toHaveClass('logo-mark--hover');
+			expect(logoMark).toHaveClass('logo-mark--showcase');
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Add border to desktop mode logo button (consistent with hamburger mode)
- Add rainbow gradient animation on hover (6s smooth cycle using existing `#lockup-rainbow` gradient)
- Hover applies everywhere LogoLockup is used (toolbar, help panel, etc.)

## Changes

**Toolbar.svelte:**
- Added `border: 1px solid var(--colour-border)` to `.toolbar-brand--clickable`
- Added `border-color` hover state

**LogoLockup.svelte:**
- Added self-contained hover detection (`onmouseenter`/`onmouseleave`)
- Added `hovering` state that triggers `#lockup-rainbow` gradient
- Hover respects priority order: party > celebrate > showcase > hover
- Added CSS for `.logo-mark--hover` and `.logo-title--hover`

**LogoLockup.test.ts:**
- Added 6 tests for hover state behavior

## Test plan

- [x] Hover applies rainbow gradient (6s cycle)
- [x] Hover class removed on mouseleave
- [x] Hover doesn't override party/celebrate/showcase modes
- [x] All 2333 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)