### PR TITLE
fix: shelf devices default to full depth (#160)

### DIFF
--- a/src/lib/data/starterLibrary.ts
+++ b/src/lib/data/starterLibrary.ts
@@ -57,9 +57,9 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
 	{ name: '1U Blank', u_height: 1, category: 'blank', is_full_depth: false },
 	{ name: '2U Blank', u_height: 2, category: 'blank', is_full_depth: false },
 
-	// Shelf devices (2) - half-depth
-	{ name: '1U Shelf', u_height: 1, category: 'shelf', is_full_depth: false },
-	{ name: '2U Shelf', u_height: 2, category: 'shelf', is_full_depth: false },
+	// Shelf devices (2) - full depth (shelves span entire rack depth)
+	{ name: '1U Shelf', u_height: 1, category: 'shelf', is_full_depth: true },
+	{ name: '2U Shelf', u_height: 2, category: 'shelf', is_full_depth: true },
 
 	// Cable management (2) - half-depth
 	{ name: '1U Brush Panel', u_height: 1, category: 'cable-management', is_full_depth: false },

--- a/src/lib/stores/layout-helpers.ts
+++ b/src/lib/stores/layout-helpers.ts
@@ -64,8 +64,12 @@ export function createDeviceType(data: CreateDeviceTypeInput): DeviceType {
 	} else if (data.name) {
 		deviceType.model = data.name;
 	}
+	// Handle is_full_depth: explicit value takes precedence, otherwise default based on category
 	if (data.is_full_depth !== undefined) {
 		deviceType.is_full_depth = data.is_full_depth;
+	} else if (data.category === 'shelf') {
+		// Shelf devices span full rack depth by design
+		deviceType.is_full_depth = true;
 	}
 	if (data.weight !== undefined) {
 		deviceType.weight = data.weight;

--- a/src/tests/layout-helpers.test.ts
+++ b/src/tests/layout-helpers.test.ts
@@ -250,6 +250,49 @@ describe('createDeviceType', () => {
 
 		expect(result.slug).toBe(`device-${mockTimestamp}`);
 	});
+
+	it('defaults is_full_depth to true for shelf category', () => {
+		const input: CreateDeviceTypeInput = {
+			name: '1U Shelf',
+			u_height: 1,
+			category: 'shelf',
+			colour: '#8BE9FD'
+		};
+
+		const result = createDeviceType(input);
+
+		// Shelf devices span full rack depth by design
+		expect(result.is_full_depth).toBe(true);
+	});
+
+	it('allows explicit is_full_depth override for shelf category', () => {
+		const input: CreateDeviceTypeInput = {
+			name: 'Half Depth Shelf',
+			u_height: 1,
+			category: 'shelf',
+			colour: '#8BE9FD',
+			is_full_depth: false
+		};
+
+		const result = createDeviceType(input);
+
+		// Explicit override should be respected
+		expect(result.is_full_depth).toBe(false);
+	});
+
+	it('does not auto-set is_full_depth for non-shelf categories', () => {
+		const input: CreateDeviceTypeInput = {
+			name: 'Server',
+			u_height: 2,
+			category: 'server',
+			colour: '#336699'
+		};
+
+		const result = createDeviceType(input);
+
+		// Non-shelf categories should not have is_full_depth auto-set
+		expect(result.is_full_depth).toBeUndefined();
+	});
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Shelf devices now automatically default to `is_full_depth: true` in `createDeviceType()`
- Updated starterLibrary shelf devices from `is_full_depth: false` to `true`
- Explicit `is_full_depth` values still respected when provided

## Files Changed
- `src/lib/stores/layout-helpers.ts`: Add shelf category detection in createDeviceType
- `src/lib/data/starterLibrary.ts`: Fix existing shelf devices to be full depth
- `src/tests/layout-helpers.test.ts`: Add tests for shelf defaulting behavior

## Test Plan
- [x] New shelf devices created via `createDeviceType()` default to `is_full_depth: true`
- [x] Explicit `is_full_depth: false` override still works for shelf category
- [x] Non-shelf categories don't auto-set `is_full_depth`
- [x] Starter library shelf devices now show as full depth
- [x] All existing tests pass

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)