### PR TITLE
fix: correct hatched blocking logic for device depth (#161)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -132,13 +132,25 @@
 	const effectiveFaceFilter = $derived(faceFilter ?? rack.view);
 
 	// Filter devices by face and preserve original indices for selection tracking
+	// Full-depth devices are visible from both sides, so they appear on both faces
 	const visibleDevices = $derived(
 		rack.devices
 			.map((placedDevice, originalIndex) => ({ placedDevice, originalIndex }))
 			.filter(({ placedDevice }) => {
 				const { face } = placedDevice;
-				if (face === 'both') return true; // Both-face devices visible in all views
-				return face === effectiveFaceFilter; // Show devices matching the filter
+				// Both-face devices visible in all views
+				if (face === 'both') return true;
+				// Devices on this face are always visible
+				if (face === effectiveFaceFilter) return true;
+				// Full-depth devices on the opposite face are also visible (they span full rack depth)
+				if (faceFilter) {
+					const deviceType = getDeviceBySlug(placedDevice.device_type);
+					if (deviceType) {
+						const isFullDepth = deviceType.is_full_depth !== false;
+						if (isFullDepth) return true;
+					}
+				}
+				return false;
 			})
 	);
 

--- a/src/tests/RackDualView.test.ts
+++ b/src/tests/RackDualView.test.ts
@@ -248,8 +248,33 @@ describe('RackDualView Component', () => {
 	});
 
 	describe('Device Display', () => {
-		it('shows front-face devices only in front view', () => {
+		it('shows half-depth front-face devices only in front view', () => {
 			const rack = createTestRack({
+				// device-2 is half-depth, so it should only appear on its face
+				devices: [{ device_type: 'device-2', position: 1, face: 'front' }]
+			});
+			const { container } = render(RackDualView, {
+				props: {
+					rack,
+					deviceLibrary: createTestDeviceLibrary(),
+					selected: false
+				}
+			});
+
+			const frontView = container.querySelector('.rack-front');
+			const rearView = container.querySelector('.rack-rear');
+
+			// Half-depth device should only be in front view
+			const frontDevices = frontView?.querySelectorAll('.rack-device');
+			const rearDevices = rearView?.querySelectorAll('.rack-device');
+
+			expect(frontDevices?.length).toBe(1);
+			expect(rearDevices?.length).toBe(0);
+		});
+
+		it('shows full-depth front-face devices in both views', () => {
+			const rack = createTestRack({
+				// device-1 is full-depth, so it should be visible from both sides
 				devices: [{ device_type: 'device-1', position: 1, face: 'front' }]
 			});
 			const { container } = render(RackDualView, {
@@ -263,12 +288,12 @@ describe('RackDualView Component', () => {
 			const frontView = container.querySelector('.rack-front');
 			const rearView = container.querySelector('.rack-rear');
 
-			// Device should be in front view
+			// Full-depth device should be visible in both views
 			const frontDevices = frontView?.querySelectorAll('.rack-device');
 			const rearDevices = rearView?.querySelectorAll('.rack-device');
 
 			expect(frontDevices?.length).toBe(1);
-			expect(rearDevices?.length).toBe(0);
+			expect(rearDevices?.length).toBe(1);
 		});
 
 		it('shows rear-face devices only in rear view', () => {

--- a/src/tests/export.test.ts
+++ b/src/tests/export.test.ts
@@ -1130,18 +1130,18 @@ describe('QR Code Export', () => {
 describe('Dual-View Export', () => {
 	const mockDevices: DeviceType[] = [
 		{
-			slug: 'front-server',
-			model: 'Front Server',
-			u_height: 2,
-			is_full_depth: true,
+			slug: 'front-switch',
+			model: 'Front Switch',
+			u_height: 1,
+			is_full_depth: false, // half-depth, only visible on front
 			colour: '#4A90D9',
-			category: 'server'
+			category: 'network'
 		},
 		{
 			slug: 'rear-patch',
 			model: 'Rear Patch Panel',
 			u_height: 1,
-			is_full_depth: false,
+			is_full_depth: false, // half-depth, only visible on rear
 			colour: '#7B68EE',
 			category: 'network'
 		},
@@ -1164,7 +1164,7 @@ describe('Dual-View Export', () => {
 			form_factor: '4-post',
 			starting_unit: 1,
 			devices: [
-				{ id: 'dual-1', device_type: 'front-server', position: 1, face: 'front' },
+				{ id: 'dual-1', device_type: 'front-switch', position: 1, face: 'front' },
 				{ id: 'dual-2', device_type: 'rear-patch', position: 5, face: 'rear' },
 				{ id: 'dual-3', device_type: 'both-ups', position: 8, face: 'both' }
 			]
@@ -1186,7 +1186,7 @@ describe('Dual-View Export', () => {
 			const svgString = svg.outerHTML;
 
 			// Should include front and both-face devices
-			expect(svgString).toContain('#4A90D9'); // front-server (front)
+			expect(svgString).toContain('#4A90D9'); // front-switch (front)
 			expect(svgString).toContain('#22C55E'); // both-ups (both)
 			// Should NOT include rear-only devices
 			expect(svgString).not.toContain('#7B68EE'); // rear-patch (rear)
@@ -1208,8 +1208,8 @@ describe('Dual-View Export', () => {
 			// Should include rear and both-face devices
 			expect(svgString).toContain('#7B68EE'); // rear-patch (rear)
 			expect(svgString).toContain('#22C55E'); // both-ups (both)
-			// Should NOT include front-only devices
-			expect(svgString).not.toContain('#4A90D9'); // front-server (front)
+			// Should NOT include front-only half-depth devices
+			expect(svgString).not.toContain('#4A90D9'); // front-switch (front)
 		});
 
 		it('exports both views side-by-side when exportView is "both"', () => {
@@ -1230,7 +1230,7 @@ describe('Dual-View Export', () => {
 			expect(svgString).toContain('REAR');
 
 			// All device colours should be present (different faces in different views)
-			expect(svgString).toContain('#4A90D9'); // front-server
+			expect(svgString).toContain('#4A90D9'); // front-switch
 			expect(svgString).toContain('#7B68EE'); // rear-patch
 			expect(svgString).toContain('#22C55E'); // both-ups (appears in both)
 		});
@@ -1249,7 +1249,7 @@ describe('Dual-View Export', () => {
 			const svgString = svg.outerHTML;
 
 			// Legacy behavior: all devices visible
-			expect(svgString).toContain('#4A90D9'); // front-server
+			expect(svgString).toContain('#4A90D9'); // front-switch
 			expect(svgString).toContain('#7B68EE'); // rear-patch
 			expect(svgString).toContain('#22C55E'); // both-ups
 		});
@@ -1416,7 +1416,7 @@ describe('Dual-View Export', () => {
 
 			// All devices should be in legend
 			const legendItems = legend?.querySelectorAll('.legend-item');
-			expect(legendItems?.length).toBe(3); // front-server, rear-patch, both-ups
+			expect(legendItems?.length).toBe(3); // front-switch, rear-patch, both-ups
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Full-depth devices are now visible from both rack faces (no hatching needed)
- Half-depth devices show hatching pattern on the opposite face only
- Added blocked slot visualization to SVG exports
- Fixed visibleDevices filter in Rack component to include full-depth devices from opposite face

## Changes

**Core Logic:**
- `blocked-slots.ts`: Inverted logic - now calculates blocked slots for half-depth devices only
- `Rack.svelte`: Updated visibleDevices filter to include full-depth devices regardless of face

**Export:**
- `export.ts`: Added blocked slot rendering with diagonal stripe hatching pattern
- `export.ts`: Updated filterDevicesByFace to include full-depth devices

**Tests:**
- Updated blocked-slots tests for corrected behavior
- Updated Rack component tests for full-depth visibility
- Updated RackDualView tests with new half-depth/full-depth distinction
- Updated export tests to use half-depth devices for face filtering

## Test plan

- [x] All 2337 tests pass
- [x] Lint passes
- [x] Build succeeds
- [ ] Verify in browser: full-depth device placed on front face appears in rear view
- [ ] Verify in browser: half-depth device on front face shows hatching on rear view
- [ ] Verify exported images show hatching for half-depth devices

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)