### PR TITLE
fix: mobile device type icons render incorrectly in rack view (#157)

### DIFF
--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -212,7 +212,8 @@
 				height={deviceHeight}
 				class="label-overlay-wrapper"
 			>
-				<div class="label-overlay">{displayName}</div>
+				<!-- xmlns required for foreignObject HTML content on mobile browsers -->
+				<div xmlns="http://www.w3.org/1999/xhtml" class="label-overlay">{displayName}</div>
 			</foreignObject>
 		{/if}
 	{:else}
@@ -230,7 +231,8 @@
 		<!-- Category icon (vertically centered) -->
 		{#if deviceHeight >= 22}
 			<foreignObject x="8" y="0" width="16" height={deviceHeight} class="category-icon-wrapper">
-				<div class="icon-container">
+				<!-- xmlns required for foreignObject HTML content on mobile browsers -->
+				<div xmlns="http://www.w3.org/1999/xhtml" class="icon-container">
 					<CategoryIcon category={device.category} size={14} />
 				</div>
 			</foreignObject>
@@ -239,7 +241,9 @@
 
 	<!-- Invisible HTML overlay for drag-and-drop (rendered last to be on top for click events) -->
 	<foreignObject x="0" y="0" width={deviceWidth} height={deviceHeight} class="drag-overlay">
+		<!-- xmlns required for foreignObject HTML content on mobile browsers -->
 		<div
+			xmlns="http://www.w3.org/1999/xhtml"
 			bind:this={dragHandleElement}
 			class="drag-handle"
 			role="button"


### PR DESCRIPTION
## Summary

- Add `xmlns="http://www.w3.org/1999/xhtml"` to HTML content within SVG foreignObject elements
- Fixes icon positioning issues on mobile browsers

## Technical Details

On mobile browsers (particularly Safari), HTML content inside SVG `foreignObject` elements can render at incorrect positions if the XHTML namespace is not explicitly declared. This is because the browser may not properly infer the namespace from context, causing the HTML content to be positioned relative to the document root rather than the SVG coordinate space.

This fix adds the required namespace to:
- Category icon wrapper (left side of device)
- Label overlay wrapper (used in image mode)
- Drag handle overlay (invisible click/drag target)

## Test plan

- [x] All tests pass
- [x] Build succeeds
- [ ] Test on mobile device: verify icons appear on their respective devices
- [ ] Test on narrow viewport: icons should stay positioned correctly

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)