### PR TITLE
fix: correct SVG viewBox attribute in LogoLockup title (#166)

### DIFF
--- a/src/lib/components/LogoLockup.svelte
+++ b/src/lib/components/LogoLockup.svelte
@@ -206,7 +206,7 @@
 		class:logo-title--party={partyMode}
 		class:logo-title--showcase={showcase}
 		class:logo-title--hover={hovering && !partyMode && !celebrate && !showcase}
-		viewBox="0 0 200 50"
+		viewBox="0 0 160 50"
 		height={titleHeight}
 		role="img"
 		aria-label="Rackarr"

--- a/src/tests/IconLogo.test.ts
+++ b/src/tests/IconLogo.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import IconLogo from '$lib/components/icons/IconLogo.svelte';
+
+describe('IconLogo', () => {
+	describe('Rendering', () => {
+		it('renders the logo SVG', () => {
+			const { container } = render(IconLogo);
+			const svg = container.querySelector('svg.logo-icon');
+
+			expect(svg).toBeInTheDocument();
+		});
+
+		it('has correct default size', () => {
+			const { container } = render(IconLogo);
+			const svg = container.querySelector('svg.logo-icon');
+
+			expect(svg).toHaveAttribute('width', '20');
+			expect(svg).toHaveAttribute('height', '20');
+		});
+
+		it('accepts custom size prop', () => {
+			const { container } = render(IconLogo, { props: { size: 32 } });
+			const svg = container.querySelector('svg.logo-icon');
+
+			expect(svg).toHaveAttribute('width', '32');
+			expect(svg).toHaveAttribute('height', '32');
+		});
+	});
+
+	describe('SVG viewBox Validation (#166)', () => {
+		it('has correct viewBox', () => {
+			const { container } = render(IconLogo);
+			const svg = container.querySelector('svg.logo-icon');
+
+			expect(svg).toHaveAttribute('viewBox', '0 0 48 48');
+		});
+
+		it('viewBox has exactly 4 values', () => {
+			const { container } = render(IconLogo);
+			const svg = container.querySelector('svg.logo-icon');
+			const viewBox = svg?.getAttribute('viewBox');
+
+			// Validate format: exactly 4 space-separated numeric values
+			const values = viewBox?.split(' ');
+			expect(values).toHaveLength(4);
+			values?.forEach((val) => {
+				expect(Number.isNaN(parseFloat(val))).toBe(false);
+			});
+		});
+
+		it('viewBox starts at origin (0 0)', () => {
+			const { container } = render(IconLogo);
+			const svg = container.querySelector('svg.logo-icon');
+			const viewBox = svg?.getAttribute('viewBox');
+			const [minX, minY] = viewBox?.split(' ').map(Number) ?? [];
+
+			expect(minX).toBe(0);
+			expect(minY).toBe(0);
+		});
+	});
+
+	describe('Logo Structure', () => {
+		it('contains rack frame', () => {
+			const { container } = render(IconLogo);
+			const frame = container.querySelector('.logo-frame');
+
+			expect(frame).toBeInTheDocument();
+		});
+
+		it('contains rack interior', () => {
+			const { container } = render(IconLogo);
+			const interior = container.querySelector('.logo-interior');
+
+			expect(interior).toBeInTheDocument();
+		});
+
+		it('contains three device slots', () => {
+			const { container } = render(IconLogo);
+			const device1 = container.querySelector('.logo-device-1');
+			const device2 = container.querySelector('.logo-device-2');
+			const device3 = container.querySelector('.logo-device-3');
+
+			expect(device1).toBeInTheDocument();
+			expect(device2).toBeInTheDocument();
+			expect(device3).toBeInTheDocument();
+		});
+	});
+
+	describe('Accessibility', () => {
+		it('is hidden from screen readers', () => {
+			const { container } = render(IconLogo);
+			const svg = container.querySelector('svg.logo-icon');
+
+			expect(svg).toHaveAttribute('aria-hidden', 'true');
+		});
+	});
+});

--- a/src/tests/LogoLoader.test.ts
+++ b/src/tests/LogoLoader.test.ts
@@ -33,6 +33,19 @@ describe('LogoLoader', () => {
 
 			expect(svg).toHaveAttribute('viewBox', '0 0 32 32');
 		});
+
+		it('viewBox has exactly 4 values (#166)', () => {
+			const { container } = render(LogoLoader);
+			const svg = container.querySelector('svg.logo-mark');
+			const viewBox = svg?.getAttribute('viewBox');
+
+			// Validate format: exactly 4 space-separated numeric values
+			const values = viewBox?.split(' ');
+			expect(values).toHaveLength(4);
+			values?.forEach((val) => {
+				expect(Number.isNaN(parseFloat(val))).toBe(false);
+			});
+		});
 	});
 
 	describe('Logo Structure', () => {

--- a/src/tests/LogoLockup.test.ts
+++ b/src/tests/LogoLockup.test.ts
@@ -230,4 +230,59 @@ describe('LogoLockup', () => {
 			expect(defsSvg).toHaveAttribute('aria-hidden', 'true');
 		});
 	});
+
+	describe('SVG viewBox Validation (#166)', () => {
+		// Regression tests for malformed viewBox attributes
+		// viewBox format must be: "minX minY width height" (4 space-separated values)
+
+		it('logo-mark has valid viewBox with 4 values', () => {
+			const { container } = render(LogoLockup);
+			const logoMark = container.querySelector('.logo-mark');
+			const viewBox = logoMark?.getAttribute('viewBox');
+
+			expect(viewBox).toBe('0 0 32 32');
+
+			// Validate format: exactly 4 space-separated numeric values
+			const values = viewBox?.split(' ');
+			expect(values).toHaveLength(4);
+			values?.forEach((val) => {
+				expect(Number.isNaN(parseFloat(val))).toBe(false);
+			});
+		});
+
+		it('logo-title has valid viewBox with 4 values', () => {
+			const { container } = render(LogoLockup);
+			const logoTitle = container.querySelector('.logo-title');
+			const viewBox = logoTitle?.getAttribute('viewBox');
+
+			expect(viewBox).toBe('0 0 160 50');
+
+			// Validate format: exactly 4 space-separated numeric values
+			const values = viewBox?.split(' ');
+			expect(values).toHaveLength(4);
+			values?.forEach((val) => {
+				expect(Number.isNaN(parseFloat(val))).toBe(false);
+			});
+		});
+
+		it('logo-mark viewBox starts at origin (0 0)', () => {
+			const { container } = render(LogoLockup);
+			const logoMark = container.querySelector('.logo-mark');
+			const viewBox = logoMark?.getAttribute('viewBox');
+			const [minX, minY] = viewBox?.split(' ').map(Number) ?? [];
+
+			expect(minX).toBe(0);
+			expect(minY).toBe(0);
+		});
+
+		it('logo-title viewBox starts at origin (0 0)', () => {
+			const { container } = render(LogoLockup);
+			const logoTitle = container.querySelector('.logo-title');
+			const viewBox = logoTitle?.getAttribute('viewBox');
+			const [minX, minY] = viewBox?.split(' ').map(Number) ?? [];
+
+			expect(minX).toBe(0);
+			expect(minY).toBe(0);
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Fixed logo-title viewBox from `"0 0 200 50"` to `"0 0 160 50"` 
- Added comprehensive viewBox validation tests for all logo components
- Created new IconLogo.test.ts with full test coverage

## Test plan
- [x] All logo viewBox tests pass
- [x] LogoLockup renders correctly with updated viewBox
- [x] Build succeeds

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)