### PR TITLE
fix: pass target face and depth to drag-drop validation (#168)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -212,7 +212,9 @@
 			deviceLibrary,
 			dragData.device.u_height,
 			targetU,
-			excludeIndex
+			excludeIndex,
+			effectiveFaceFilter,
+			dragData.device.is_full_depth ?? true
 		);
 
 		dropPreview = {
@@ -287,7 +289,9 @@
 			deviceLibrary,
 			dragData.device.u_height,
 			targetU,
-			excludeIndex
+			excludeIndex,
+			effectiveFaceFilter,
+			dragData.device.is_full_depth ?? true
 		);
 
 		if (feedback === 'valid') {

--- a/src/lib/utils/dragdrop.ts
+++ b/src/lib/utils/dragdrop.ts
@@ -3,7 +3,7 @@
  * Handles drag data, position calculation, and drop validation
  */
 
-import type { DeviceType, Rack } from '$lib/types';
+import type { DeviceType, DeviceFace, Rack } from '$lib/types';
 import { canPlaceDevice } from './collision';
 
 /**
@@ -67,6 +67,8 @@ export function calculateDropPosition(
  * @param deviceHeight - Height of device being dropped
  * @param targetU - Target U position
  * @param excludeIndex - Optional device index to exclude from collision check (for moves within same rack)
+ * @param targetFace - Target face for placement (defaults to 'front')
+ * @param isFullDepth - Whether the device being dropped is full-depth (defaults to true)
  * @returns Feedback: 'valid', 'invalid', or 'blocked'
  */
 export function getDropFeedback(
@@ -74,7 +76,9 @@ export function getDropFeedback(
 	deviceLibrary: DeviceType[],
 	deviceHeight: number,
 	targetU: number,
-	excludeIndex?: number
+	excludeIndex?: number,
+	targetFace: DeviceFace = 'front',
+	isFullDepth: boolean = true
 ): DropFeedback {
 	// Check bounds first
 	if (targetU < 1) {
@@ -85,8 +89,16 @@ export function getDropFeedback(
 		return 'invalid';
 	}
 
-	// Check for collisions
-	const canPlace = canPlaceDevice(rack, deviceLibrary, deviceHeight, targetU, excludeIndex);
+	// Check for collisions with face-aware validation
+	const canPlace = canPlaceDevice(
+		rack,
+		deviceLibrary,
+		deviceHeight,
+		targetU,
+		excludeIndex,
+		targetFace,
+		isFullDepth
+	);
 
 	if (!canPlace) {
 		return 'blocked';


### PR DESCRIPTION
## Summary
- Added `targetFace` and `isFullDepth` parameters to `getDropFeedback()` function
- Updated `Rack.svelte` to pass `effectiveFaceFilter` and `device.is_full_depth` to validation
- Added 6 comprehensive face-aware drop feedback tests

## Root Cause
The drag-and-drop validation was calling `canPlaceDevice()` without the `targetFace` and `isFullDepth` parameters, causing them to default to `'front'` and `true`. This incorrectly blocked valid placements of half-depth devices on opposite faces.

## Changes
| File | Change |
|------|--------|
| `src/lib/utils/dragdrop.ts` | Extended `getDropFeedback()` signature with face/depth params |
| `src/lib/components/Rack.svelte` | Pass `effectiveFaceFilter` and `is_full_depth` in 2 locations |
| `src/tests/dragdrop.test.ts` | Added 6 face-aware validation tests |

## Test plan
- [x] Half-depth device can be dragged to rear face when half-depth front device exists at same U
- [x] Half-depth device can be dragged to front face when half-depth rear device exists at same U
- [x] Full-depth devices still block both faces (existing behavior preserved)
- [x] Behavior matches keyboard movement in all face/depth scenarios

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)