### PR TITLE
chore: add error capture to bare catch blocks (#146)

### DIFF
--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -165,8 +165,9 @@ export function trackEvent<E extends keyof AnalyticsEvents>(
 		} else {
 			window.umami?.track(eventName);
 		}
-	} catch {
-		// Silently fail - analytics should never break the app
+	} catch (e) {
+		// Analytics errors should not break the app, but log for debugging
+		console.warn('[rackarr] Analytics tracking failed:', e);
 	}
 }
 

--- a/src/lib/utils/import.ts
+++ b/src/lib/utils/import.ts
@@ -122,7 +122,8 @@ export function parseDeviceLibraryImport(
 	// Parse JSON
 	try {
 		data = JSON.parse(json);
-	} catch {
+	} catch (e) {
+		console.warn('[rackarr] Failed to parse device library JSON:', e);
 		return { devices: [], skipped: 0 };
 	}
 

--- a/src/lib/utils/session.ts
+++ b/src/lib/utils/session.ts
@@ -16,8 +16,9 @@ export function saveToSession(layout: Layout): void {
 	try {
 		const json = JSON.stringify(layout);
 		sessionStorage.setItem(STORAGE_KEY, json);
-	} catch {
+	} catch (e) {
 		// sessionStorage not available or quota exceeded
+		console.warn('[rackarr] Failed to save layout to sessionStorage:', e);
 	}
 }
 
@@ -41,8 +42,9 @@ export function loadFromSession(): Layout | null {
 		}
 
 		return result.data as Layout;
-	} catch {
+	} catch (e) {
 		// sessionStorage not available or invalid JSON
+		console.warn('[rackarr] Failed to load layout from sessionStorage:', e);
 		return null;
 	}
 }
@@ -53,8 +55,9 @@ export function loadFromSession(): Layout | null {
 export function clearSession(): void {
 	try {
 		sessionStorage.removeItem(STORAGE_KEY);
-	} catch {
+	} catch (e) {
 		// sessionStorage not available
+		console.warn('[rackarr] Failed to clear sessionStorage:', e);
 	}
 }
 

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -16,8 +16,9 @@ export function loadThemeFromStorage(): Theme {
 		if (stored === 'light' || stored === 'dark') {
 			return stored;
 		}
-	} catch {
+	} catch (e) {
 		// localStorage not available (SSR or privacy mode)
+		console.warn('[rackarr] Failed to load theme from localStorage:', e);
 	}
 	return 'dark';
 }
@@ -29,8 +30,9 @@ export function loadThemeFromStorage(): Theme {
 export function saveThemeToStorage(theme: Theme): void {
 	try {
 		localStorage.setItem(THEME_STORAGE_KEY, theme);
-	} catch {
+	} catch (e) {
 		// localStorage not available (SSR or privacy mode)
+		console.warn('[rackarr] Failed to save theme to localStorage:', e);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `[rackarr]` prefix to all console.warn messages for easy log filtering
- Add error parameter and logging to 7 bare catch blocks across 4 files
- Use `console.warn` for all recoverable errors (localStorage/sessionStorage not available, JSON parse failures, analytics errors)

## Files Changed
- `src/lib/utils/theme.ts`: Log localStorage access failures
- `src/lib/utils/session.ts`: Log sessionStorage access failures  
- `src/lib/utils/import.ts`: Log JSON parse failures
- `src/lib/utils/analytics.ts`: Log analytics tracking failures

## Test Plan
- [x] Lint passes
- [x] All tests pass (2360 tests)
- [x] Build succeeds

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)