### PR TITLE
chore: extract device lookup to shared utility (#151)

### DIFF
--- a/src/lib/utils/device-lookup.ts
+++ b/src/lib/utils/device-lookup.ts
@@ -1,0 +1,60 @@
+/**
+ * Device Type Lookup Utility
+ * Unified lookup across all device sources with clear priority order
+ */
+
+import type { DeviceType } from '$lib/types';
+import { findStarterDevice } from '$lib/data/starterLibrary';
+import { findBrandDevice } from '$lib/data/brandPacks';
+
+/**
+ * Find a device type by slug across all sources
+ *
+ * Priority order:
+ * 1. Layout device_types (user's custom/imported types)
+ * 2. Starter pack (generic devices)
+ * 3. Brand packs (vendor-specific devices)
+ *
+ * @param slug - Device type slug to find
+ * @param layoutDeviceTypes - Device types from the current layout (optional)
+ * @returns DeviceType or undefined if not found
+ */
+export function findDeviceType(
+	slug: string,
+	layoutDeviceTypes: DeviceType[] = []
+): DeviceType | undefined {
+	// 1. Check layout's device_types first (user's custom/imported)
+	const layoutDevice = layoutDeviceTypes.find((dt) => dt.slug === slug);
+	if (layoutDevice) {
+		return layoutDevice;
+	}
+
+	// 2. Check starter pack
+	const starterDevice = findStarterDevice(slug);
+	if (starterDevice) {
+		return starterDevice;
+	}
+
+	// 3. Check brand packs
+	const brandDevice = findBrandDevice(slug);
+	if (brandDevice) {
+		return brandDevice;
+	}
+
+	return undefined;
+}
+
+/**
+ * Find a device type in a specific device library array
+ * Simpler version for when you already have the combined library
+ *
+ * @param deviceLibrary - Array of device types to search
+ * @param slug - Device type slug to find
+ * @returns DeviceType or undefined if not found
+ */
+export function findDeviceInLibrary(
+	deviceLibrary: DeviceType[],
+	slug: string
+): DeviceType | undefined {
+	return deviceLibrary.find((dt) => dt.slug === slug);
+}

--- a/src/tests/device-lookup.test.ts
+++ b/src/tests/device-lookup.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { findDeviceType, findDeviceInLibrary } from '$lib/utils/device-lookup';
+import type { DeviceType } from '$lib/types';
+
+describe('Device Lookup Utility', () => {
+	// Mock devices for testing
+	const customDevice: DeviceType = {
+		slug: 'custom-server',
+		model: 'Custom Server',
+		u_height: 2,
+		colour: '#ff0000',
+		category: 'server'
+	};
+
+	const layoutDeviceTypes: DeviceType[] = [customDevice];
+
+	describe('findDeviceType', () => {
+		it('finds device in layout device_types first (priority 1)', () => {
+			const result = findDeviceType('custom-server', layoutDeviceTypes);
+			expect(result).toBe(customDevice);
+		});
+
+		it('falls back to starter pack if not in layout (priority 2)', () => {
+			// '1u-server' is a known starter library device
+			const result = findDeviceType('1u-server', []);
+			expect(result).toBeDefined();
+			expect(result?.slug).toBe('1u-server');
+		});
+
+		it('falls back to brand packs if not in layout or starter (priority 3)', () => {
+			// 'ubiquiti-unifi-dream-machine-pro' is a known Ubiquiti device
+			const result = findDeviceType('ubiquiti-unifi-dream-machine-pro', []);
+			expect(result).toBeDefined();
+			expect(result?.slug).toBe('ubiquiti-unifi-dream-machine-pro');
+		});
+
+		it('returns undefined if not found in any source', () => {
+			const result = findDeviceType('non-existent-device-xyz-123', []);
+			expect(result).toBeUndefined();
+		});
+
+		it('layout devices take priority over starter library', () => {
+			// Create a custom device with same slug as a starter device
+			const customOverride: DeviceType = {
+				slug: '1u-server',
+				model: 'My Custom 1U',
+				u_height: 1,
+				colour: '#0000ff',
+				category: 'server'
+			};
+
+			const result = findDeviceType('1u-server', [customOverride]);
+			expect(result).toBe(customOverride);
+			expect(result?.model).toBe('My Custom 1U');
+		});
+
+		it('layout devices take priority over brand packs', () => {
+			// Create a custom device with same slug as a brand device
+			const customOverride: DeviceType = {
+				slug: 'ubiquiti-unifi-dream-machine-pro',
+				model: 'My Custom UDM',
+				u_height: 1,
+				colour: '#00ff00',
+				category: 'server'
+			};
+
+			const result = findDeviceType('ubiquiti-unifi-dream-machine-pro', [customOverride]);
+			expect(result).toBe(customOverride);
+			expect(result?.model).toBe('My Custom UDM');
+		});
+
+		it('works with empty layout device types array', () => {
+			const result = findDeviceType('1u-server', []);
+			expect(result).toBeDefined();
+		});
+
+		it('works without layout device types parameter (defaults to empty)', () => {
+			const result = findDeviceType('1u-server');
+			expect(result).toBeDefined();
+		});
+	});
+
+	describe('findDeviceInLibrary', () => {
+		const library: DeviceType[] = [
+			{ slug: 'device-a', model: 'A', u_height: 1, colour: '#000', category: 'server' },
+			{ slug: 'device-b', model: 'B', u_height: 2, colour: '#111', category: 'network' },
+			{ slug: 'device-c', model: 'C', u_height: 3, colour: '#222', category: 'storage' }
+		];
+
+		it('finds device by slug', () => {
+			const result = findDeviceInLibrary(library, 'device-b');
+			expect(result?.model).toBe('B');
+		});
+
+		it('returns undefined if not found', () => {
+			const result = findDeviceInLibrary(library, 'device-z');
+			expect(result).toBeUndefined();
+		});
+
+		it('works with empty library', () => {
+			const result = findDeviceInLibrary([], 'device-a');
+			expect(result).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Create unified `findDeviceType()` utility with clear priority order
- Priority: layout device_types → starter pack → brand packs
- Add `findDeviceInLibrary()` for simple array lookups
- Refactor `placeDeviceRecorded` to use new utility (cleaner, less duplication)

## Files Changed
- `src/lib/utils/device-lookup.ts`: New utility module
- `src/lib/stores/layout.svelte.ts`: Use new utility
- `src/tests/device-lookup.test.ts`: 11 new tests

## Test Plan
- [x] Lint passes
- [x] All tests pass (2371 tests, 11 new)
- [x] Build succeeds

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)