### PR TITLE
fix: allow 'both' face value in updateDeviceFaceRaw (#174)

### DIFF
--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -624,7 +624,7 @@ function moveDeviceRaw(index: number, newPosition: number): boolean {
  * @param index - Device index
  * @param face - New face value
  */
-function updateDeviceFaceRaw(index: number, face: 'front' | 'rear'): void {
+function updateDeviceFaceRaw(index: number, face: DeviceFace): void {
 	if (index < 0 || index >= layout.rack.devices.length) return;
 
 	layout = {


### PR DESCRIPTION
## Summary
- Fixed type signature in `updateDeviceFaceRaw` function that was incorrectly restricting face to `'front' | 'rear'` instead of `DeviceFace`
- This was preventing users from selecting "Both (full-depth)" option in the Edit Panel for devices

## Root Cause
The command interface at `device.ts:15` correctly expected `DeviceFace`, but the implementation at `layout.svelte.ts:627` used a narrower type that excluded 'both'.

## Test plan
- [x] All 2371 tests pass
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual: Edit a full-depth device, change face from "Both" to "Front" or "Rear", verify device renders only on selected face

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)