### PR TITLE
feat: complete party mode canvas effects (#173)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -105,11 +105,11 @@ import { getLayoutStore } from '$lib/stores/layout.svelte';
 		partyMode = true;
 		toastStore.showToast('Party Mode!', 'info', 3000);
 
-		// Auto-disable after 5 seconds
+		// Auto-disable after 10 seconds
 		partyModeTimeout = setTimeout(() => {
 			partyMode = false;
 			partyModeTimeout = null;
-		}, 5000);
+		}, 10_000);
 	}
 
 	// Auto-open new rack dialog when no racks exist (first-load experience)
@@ -646,7 +646,7 @@ import { getLayoutStore } from '$lib/stores/layout.svelte';
 			</Sidebar>
 		{/if}
 
-		<Canvas onnewrack={handleNewRack} onload={handleLoad} />
+		<Canvas onnewrack={handleNewRack} onload={handleLoad} {partyMode} />
 
 		{#if !viewportStore.isMobile}
 			<EditPanel />

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -19,6 +19,7 @@
 	const RACK_ID = 'rack-0';
 
 	interface Props {
+		partyMode?: boolean;
 		onnewrack?: () => void;
 		onload?: () => void;
 		onrackselect?: (event: CustomEvent<{ rackId: string }>) => void;
@@ -45,6 +46,7 @@
 	}
 
 	let {
+		partyMode = false,
 		onnewrack,
 		onload: _onload,
 		onrackselect,
@@ -205,6 +207,7 @@
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
 	class="canvas"
+	class:party-mode={partyMode}
 	role="application"
 	aria-label="Rack layout canvas"
 	bind:this={canvasContainer}
@@ -224,6 +227,7 @@
 						: null}
 					displayMode={uiStore.displayMode}
 					showLabelsOnImages={uiStore.showLabelsOnImages}
+					{partyMode}
 					onselect={(e) => handleRackSelect(e)}
 					ondeviceselect={(e) => handleDeviceSelect(e)}
 					ondevicedrop={(e) => handleDeviceDrop(e)}
@@ -265,5 +269,32 @@
 		/* Note: fitAll() in canvas store handles centering via pan calculations */
 		display: inline-block;
 		padding: var(--space-4);
+	}
+
+	/* Party mode: animated gradient background */
+	@keyframes party-bg {
+		0% {
+			background-color: hsl(0, 30%, 12%);
+		}
+		33% {
+			background-color: hsl(120, 30%, 12%);
+		}
+		66% {
+			background-color: hsl(240, 30%, 12%);
+		}
+		100% {
+			background-color: hsl(360, 30%, 12%);
+		}
+	}
+
+	.canvas.party-mode {
+		animation: party-bg 4s linear infinite;
+	}
+
+	/* Respect reduced motion preference */
+	@media (prefers-reduced-motion: reduce) {
+		.canvas.party-mode {
+			animation: none;
+		}
 	}
 </style>

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -35,6 +35,8 @@
 		viewLabel?: string;
 		/** Hide the rack name (useful when container shows it instead) */
 		hideRackName?: boolean;
+		/** Party mode visual effects active */
+		partyMode?: boolean;
 		onselect?: (event: CustomEvent<{ rackId: string }>) => void;
 		ondeviceselect?: (event: CustomEvent<{ slug: string; position: number }>) => void;
 		ondevicedrop?: (event: CustomEvent<{ rackId: string; slug: string; position: number }>) => void;
@@ -61,6 +63,7 @@
 		faceFilter,
 		viewLabel,
 		hideRackName = false,
+		partyMode = false,
 		onselect,
 		ondeviceselect,
 		ondevicedrop,
@@ -340,6 +343,7 @@
 <div
 	class="rack-container"
 	class:selected
+	class:party-mode={partyMode}
 	tabindex="0"
 	aria-selected={selected}
 	role="option"
@@ -706,5 +710,36 @@
 
 	.blocked-slot-stripes {
 		pointer-events: none;
+	}
+
+	/* Party mode: rainbow glow animation */
+	@keyframes party-glow {
+		0% {
+			filter: drop-shadow(0 0 8px hsl(0, 100%, 50%));
+		}
+		25% {
+			filter: drop-shadow(0 0 8px hsl(90, 100%, 50%));
+		}
+		50% {
+			filter: drop-shadow(0 0 8px hsl(180, 100%, 50%));
+		}
+		75% {
+			filter: drop-shadow(0 0 8px hsl(270, 100%, 50%));
+		}
+		100% {
+			filter: drop-shadow(0 0 8px hsl(360, 100%, 50%));
+		}
+	}
+
+	.rack-container.party-mode .rack-svg {
+		animation: party-glow 3s linear infinite;
+	}
+
+	/* Respect reduced motion preference */
+	@media (prefers-reduced-motion: reduce) {
+		.rack-container.party-mode .rack-svg {
+			animation: none;
+			filter: drop-shadow(0 0 8px hsl(300, 100%, 50%));
+		}
 	}
 </style>

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -18,6 +18,8 @@
 		selectedDeviceIndex?: number | null;
 		displayMode?: DisplayMode;
 		showLabelsOnImages?: boolean;
+		/** Party mode visual effects active */
+		partyMode?: boolean;
 		onselect?: (event: CustomEvent<{ rackId: string }>) => void;
 		ondeviceselect?: (event: CustomEvent<{ slug: string; position: number }>) => void;
 		ondevicedrop?: (
@@ -48,6 +50,7 @@
 		selectedDeviceIndex = null,
 		displayMode = 'label',
 		showLabelsOnImages = false,
+		partyMode = false,
 		onselect,
 		ondeviceselect,
 		ondevicedrop,
@@ -122,6 +125,7 @@
 				{selectedDeviceIndex}
 				{displayMode}
 				{showLabelsOnImages}
+				{partyMode}
 				faceFilter="front"
 				hideRackName={true}
 				viewLabel="FRONT"
@@ -142,6 +146,7 @@
 				{selectedDeviceIndex}
 				{displayMode}
 				{showLabelsOnImages}
+				{partyMode}
 				faceFilter="rear"
 				hideRackName={true}
 				viewLabel="REAR"


### PR DESCRIPTION
## Summary
- Added party mode visual effects when Konami code is triggered
- Canvas background now has subtle color cycling animation
- Racks have rainbow glow effect via CSS drop-shadow filter
- Extended auto-deactivate timer from 5 to 10 seconds

## Changes
- **App.svelte**: Extended party mode timeout to 10 seconds, pass partyMode to Canvas
- **Canvas.svelte**: Accept partyMode prop, apply party-bg animation, pass to RackDualView
- **RackDualView.svelte**: Accept partyMode prop, pass to both Rack components
- **Rack.svelte**: Accept partyMode prop, apply party-glow animation to SVG

## Technical Details
- All animations use CSS keyframes (GPU accelerated)
- Respects `prefers-reduced-motion` media query
- No JavaScript intervals - pure CSS animations
- Party mode can still be dismissed with Escape key

## Test plan
- [x] All 2371 tests pass
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual: Enter Konami code (↑↑↓↓←→←→BA), verify canvas bg cycles and rack glows
- [ ] Manual: Verify party mode auto-deactivates after 10 seconds
- [ ] Manual: Verify Escape key dismisses party mode early

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)