### PR TITLE
fix: improve rack click detection to block panning inside rack area (#172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rackarr
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.5.8-blue.svg)](https://github.com/Rackarr/Rackarr/releases)
+[![Version](https://img.shields.io/badge/version-0.5.9-blue.svg)](https://github.com/Rackarr/Rackarr/releases)
 [![Tests](https://img.shields.io/badge/tests-1800%2B-brightgreen.svg)](https://github.com/Rackarr/Rackarr/actions)
 [![Demo](https://img.shields.io/badge/demo-app.rackarr.com-blue.svg)](https://app.rackarr.com/)
 


### PR DESCRIPTION
## Summary
- Fixed issue where clicking on rack wrapper elements (name, U labels, empty slots) triggered canvas panning instead of rack selection
- Enhanced panzoom's `beforeMouseDown` callback to check if click target is within a rack area

## Root Cause
The panzoom callback was only blocking pan for draggable elements (devices), but not for other rack-related elements like the rack name label, U slot backgrounds, and U labels.

## Fix
Added Priority 2 check: if target is within `.rack-dual-view`, block panning to allow click events to propagate to rack selection handlers.

```typescript
// Priority 2: Check if target is within a rack area
const isWithinRack = target.closest?.('.rack-dual-view') !== null;
if (isWithinRack) {
  return true; // Block panning, let rack selection work
}
```

## Test plan
- [x] All 2371 tests pass
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual: Click rack name - should select rack and open Edit Panel
- [ ] Manual: Click empty U slot - should select rack
- [ ] Manual: Click U number label - should select rack
- [ ] Manual: Click rack background - should select rack
- [ ] Manual: Click canvas background outside rack - should allow pan

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)