### PR TITLE
fix(ux): clarify display mode toggle button label (#178)

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -62,11 +62,11 @@
 		onhelp
 	}: Props = $props();
 
-	// Display mode labels for the 3-way toggle
+	// Display mode labels for the 3-way toggle (prefixed with "View:" to indicate current state)
 	const displayModeLabels: Record<DisplayMode, string> = {
-		label: 'Label',
-		image: 'Image',
-		'image-label': 'Image+Label'
+		label: 'View: Label',
+		image: 'View: Image',
+		'image-label': 'View: Both'
 	};
 	const displayModeLabel = $derived(displayModeLabels[displayMode]);
 

--- a/src/lib/components/ToolbarDrawer.svelte
+++ b/src/lib/components/ToolbarDrawer.svelte
@@ -75,7 +75,13 @@
 	let firstFocusableRef: HTMLButtonElement | null = $state(null);
 
 	const viewportStore = getViewportStore();
-	const displayModeLabel = $derived(displayMode === 'label' ? 'Label Mode' : 'Image Mode');
+	// Display mode labels for the 3-way toggle (prefixed with "View:" to indicate current state)
+	const displayModeLabels: Record<DisplayMode, string> = {
+		label: 'View: Label',
+		image: 'View: Image',
+		'image-label': 'View: Both'
+	};
+	const displayModeLabel = $derived(displayModeLabels[displayMode]);
 
 	function handleAction(action: (() => void) | undefined) {
 		if (action) {

--- a/src/tests/ToolbarDrawer.test.ts
+++ b/src/tests/ToolbarDrawer.test.ts
@@ -111,7 +111,7 @@ describe('ToolbarDrawer Component', () => {
 		it('renders view group with display mode, reset view, about', () => {
 			render(ToolbarDrawer, { props: { open: true } });
 
-			expect(screen.getByRole('button', { name: /mode/i })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: /view:/i })).toBeInTheDocument();
 			expect(screen.getByRole('button', { name: /reset view/i })).toBeInTheDocument();
 			expect(screen.getByRole('button', { name: /about/i })).toBeInTheDocument();
 		});


### PR DESCRIPTION
## Summary
- Updated display mode toggle labels from "Label/Image/Image+Label" to "View: Label/View: Image/View: Both"
- Added "View:" prefix to clearly indicate the button shows current state
- Changed "Image+Label" to "Both" for shorter, consistent button width

## Files Changed
- `src/lib/components/Toolbar.svelte`: Updated displayModeLabels mapping
- `src/lib/components/ToolbarDrawer.svelte`: Added 3-state mapping (was 2-state)
- `src/tests/ToolbarDrawer.test.ts`: Updated test to match new label format

## Test Plan
- [x] All unit tests pass (2371 tests)
- [x] Lint passes
- [x] Build passes
- [ ] Manual: verify toggle button shows correct label for each mode

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)