### PR TITLE
chore: extract layout constants to shared file (#150)

### DIFF
--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -10,6 +10,7 @@
 	import { getImageStore } from '$lib/stores/images.svelte';
 	import { getViewportStore } from '$lib/utils/viewport.svelte';
 	import { useLongPress } from '$lib/utils/gestures';
+	import { RAIL_WIDTH } from '$lib/constants/layout';
 
 	interface Props {
 		device: DeviceType;
@@ -76,9 +77,6 @@
 
 	// Drag handle element ref for long-press
 	let dragHandleElement: HTMLDivElement | null = $state(null);
-
-	// Rail width (matches Rack.svelte)
-	const RAIL_WIDTH = 17;
 
 	// Image overflow: how far device images extend past rack rails (Issue #9)
 	// Real equipment extends past the rails; this creates realistic front-mounting appearance

--- a/src/lib/components/WelcomeScreen.svelte
+++ b/src/lib/components/WelcomeScreen.svelte
@@ -4,25 +4,28 @@
   Click anywhere to create a new rack
 -->
 <script lang="ts">
+	import {
+		U_HEIGHT_PX,
+		BASE_RACK_WIDTH,
+		RAIL_WIDTH,
+		BASE_RACK_PADDING
+	} from '$lib/constants/layout';
+
 	interface Props {
 		onclick?: () => void;
 	}
 
 	let { onclick }: Props = $props();
 
-	// Match Rack.svelte dimensions exactly
-	const U_HEIGHT = 22;
-	const RACK_WIDTH = 220;
-	const RAIL_WIDTH = 17;
-	const RACK_PADDING = 18;
+	// Welcome screen shows a 42U rack (standard full-height rack)
 	const RACK_HEIGHT = 42;
-	const totalHeight = RACK_HEIGHT * U_HEIGHT; // 924
-	const interiorWidth = RACK_WIDTH - RAIL_WIDTH * 2; // 186
+	const totalHeight = RACK_HEIGHT * U_HEIGHT_PX;
+	const interiorWidth = BASE_RACK_WIDTH - RAIL_WIDTH * 2;
 
 	// Generate U labels (highest number at top, ascending from bottom)
 	const uLabels = Array.from({ length: RACK_HEIGHT }, (_, i) => ({
 		uNumber: RACK_HEIGHT - i,
-		yPosition: i * U_HEIGHT + U_HEIGHT / 2 + RACK_PADDING + RAIL_WIDTH
+		yPosition: i * U_HEIGHT_PX + U_HEIGHT_PX / 2 + BASE_RACK_PADDING + RAIL_WIDTH
 	}));
 
 	function handleClick() {
@@ -48,26 +51,26 @@
 	<!-- Ghostly 42U rack background (matching Rack.svelte dimensions) -->
 	<svg
 		class="ghost-rack"
-		viewBox="0 0 {RACK_WIDTH} {RACK_PADDING + RAIL_WIDTH * 2 + totalHeight}"
+		viewBox="0 0 {BASE_RACK_WIDTH} {BASE_RACK_PADDING + RAIL_WIDTH * 2 + totalHeight}"
 		aria-hidden="true"
 	>
 		<!-- Rack interior -->
 		<rect
 			x={RAIL_WIDTH}
-			y={RACK_PADDING + RAIL_WIDTH}
+			y={BASE_RACK_PADDING + RAIL_WIDTH}
 			width={interiorWidth}
 			height={totalHeight}
 			class="rack-interior"
 		/>
 
 		<!-- Top bar (horizontal) -->
-		<rect x="0" y={RACK_PADDING} width={RACK_WIDTH} height={RAIL_WIDTH} class="rack-rail" />
+		<rect x="0" y={BASE_RACK_PADDING} width={BASE_RACK_WIDTH} height={RAIL_WIDTH} class="rack-rail" />
 
 		<!-- Bottom bar (horizontal) -->
 		<rect
 			x="0"
-			y={RACK_PADDING + RAIL_WIDTH + totalHeight}
-			width={RACK_WIDTH}
+			y={BASE_RACK_PADDING + RAIL_WIDTH + totalHeight}
+			width={BASE_RACK_WIDTH}
 			height={RAIL_WIDTH}
 			class="rack-rail"
 		/>
@@ -75,7 +78,7 @@
 		<!-- Left rail (vertical) -->
 		<rect
 			x="0"
-			y={RACK_PADDING + RAIL_WIDTH}
+			y={BASE_RACK_PADDING + RAIL_WIDTH}
 			width={RAIL_WIDTH}
 			height={totalHeight}
 			class="rack-rail"
@@ -83,8 +86,8 @@
 
 		<!-- Right rail (vertical) -->
 		<rect
-			x={RACK_WIDTH - RAIL_WIDTH}
-			y={RACK_PADDING + RAIL_WIDTH}
+			x={BASE_RACK_WIDTH - RAIL_WIDTH}
+			y={BASE_RACK_PADDING + RAIL_WIDTH}
 			width={RAIL_WIDTH}
 			height={totalHeight}
 			class="rack-rail"
@@ -94,9 +97,9 @@
 		{#each Array(RACK_HEIGHT + 1) as _, i (i)}
 			<line
 				x1={RAIL_WIDTH}
-				y1={i * U_HEIGHT + RACK_PADDING + RAIL_WIDTH}
-				x2={RACK_WIDTH - RAIL_WIDTH}
-				y2={i * U_HEIGHT + RACK_PADDING + RAIL_WIDTH}
+				y1={i * U_HEIGHT_PX + BASE_RACK_PADDING + RAIL_WIDTH}
+				x2={BASE_RACK_WIDTH - RAIL_WIDTH}
+				y2={i * U_HEIGHT_PX + BASE_RACK_PADDING + RAIL_WIDTH}
 				class="rack-line"
 			/>
 		{/each}

--- a/src/lib/constants/layout.ts
+++ b/src/lib/constants/layout.ts
@@ -1,0 +1,154 @@
+/**
+ * Rack Layout Constants
+ * Centralized visual dimensions for rack rendering
+ *
+ * These values are used across:
+ * - Rack.svelte (rendering)
+ * - RackDevice.svelte (device positioning)
+ * - WelcomeScreen.svelte (ghost rack)
+ * - canvas.ts (viewport calculations)
+ * - canvas.svelte.ts (device focus)
+ * - export.ts (SVG export - imports core values)
+ *
+ * Export-specific constants (different values for print/export)
+ * remain in export.ts to avoid confusion.
+ */
+
+// =============================================================================
+// Core Rack Dimensions (universal)
+// =============================================================================
+
+/**
+ * Height of one rack unit (1U) in pixels
+ * Industry standard: 1.75" = 44.45mm ≈ 22px at our scale
+ */
+export const U_HEIGHT_PX = 22;
+
+/**
+ * Width of mounting rails and top/bottom bars in pixels
+ * Standard rack rail width representation
+ */
+export const RAIL_WIDTH = 17;
+
+/**
+ * Base rack width in pixels for a 19" rack
+ * Other widths (10", 23") scale proportionally from this base
+ */
+export const BASE_RACK_WIDTH = 220;
+
+/**
+ * Base padding at top of rack for rack name display (13px font + margin)
+ * Used when rack name is visible (standalone rack view)
+ */
+export const BASE_RACK_PADDING = 18;
+
+/**
+ * Reduced padding when rack name is hidden (in dual-view mode or exports)
+ * Provides minimal top margin for visual balance
+ */
+export const RACK_PADDING_HIDDEN = 4;
+
+/**
+ * Extra vertical offset above rack name to prevent cutoff on narrow racks
+ */
+export const NAME_Y_OFFSET = 4;
+
+// =============================================================================
+// Canvas Layout
+// =============================================================================
+
+/**
+ * Padding around rack-row container in the canvas
+ */
+export const RACK_ROW_PADDING = 16;
+
+/**
+ * Gap between front and rear views in dual-view mode
+ * Maps to --spacing-lg CSS token
+ */
+export const DUAL_VIEW_GAP = 24;
+
+/**
+ * Extra height added by dual-view wrapper
+ * Includes: padding (12+12) + gap (8) + name (~20) + margin (4) = ~56px
+ */
+export const DUAL_VIEW_EXTRA_HEIGHT = 56;
+
+/**
+ * Gap between racks in multi-rack canvas mode (unused in v0.1.1 single-rack)
+ * Note: Export uses RACK_GAP = 40 for different spacing
+ */
+export const RACK_GAP = 24;
+
+// =============================================================================
+// Fit-All Viewport Calculations
+// =============================================================================
+
+/**
+ * Padding around content for fit-all calculation
+ * Provides breathing room when fitting content to viewport
+ */
+export const FIT_ALL_PADDING = 48;
+
+/**
+ * Maximum zoom level for fit-all
+ * Prevents excessive zoom on small content
+ */
+export const FIT_ALL_MAX_ZOOM = 2;
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Calculate rack width based on nominal width in inches
+ * Scales proportionally from 19" base width
+ * @param nominalWidth - Rack width in inches (10, 19, or 23)
+ */
+export function getRackWidth(nominalWidth: number): number {
+	return Math.round((BASE_RACK_WIDTH * nominalWidth) / 19);
+}
+
+/**
+ * Calculate interior width (between rails)
+ * @param rackWidth - Total rack width in pixels
+ */
+export function getInteriorWidth(rackWidth: number): number {
+	return rackWidth - RAIL_WIDTH * 2;
+}
+
+/**
+ * Calculate total height in pixels for a given U count
+ * @param uCount - Number of rack units
+ */
+export function getTotalHeight(uCount: number): number {
+	return uCount * U_HEIGHT_PX;
+}
+
+/**
+ * Calculate viewBox height for a rack
+ * Includes padding, top bar, U slots, and bottom bar
+ * @param uCount - Number of rack units
+ * @param hideRackName - Whether rack name is hidden (affects padding)
+ */
+export function getViewBoxHeight(uCount: number, hideRackName: boolean): number {
+	const padding = hideRackName ? RACK_PADDING_HIDDEN : BASE_RACK_PADDING;
+	return padding + RAIL_WIDTH * 2 + uCount * U_HEIGHT_PX;
+}
+
+/**
+ * Calculate dual-view width for a single rack
+ * Front and rear views side by side with gap
+ */
+export function getDualViewWidth(): number {
+	return BASE_RACK_WIDTH * 2 + DUAL_VIEW_GAP;
+}
+
+/**
+ * Calculate dual-view height for a rack
+ * Includes rack height plus extra space for view labels
+ * @param uCount - Number of rack units
+ */
+export function getDualViewHeight(uCount: number): number {
+	return BASE_RACK_PADDING + RAIL_WIDTH * 2 + uCount * U_HEIGHT_PX + DUAL_VIEW_EXTRA_HEIGHT;
+}

--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -7,6 +7,15 @@ import type panzoom from 'panzoom';
 import type { Rack } from '$lib/types';
 import { calculateFitAll, racksToPositions } from '$lib/utils/canvas';
 import { debug } from '$lib/utils/debug';
+import {
+	U_HEIGHT_PX,
+	BASE_RACK_WIDTH,
+	RAIL_WIDTH,
+	BASE_RACK_PADDING,
+	RACK_ROW_PADDING,
+	DUAL_VIEW_GAP,
+	DUAL_VIEW_EXTRA_HEIGHT
+} from '$lib/constants/layout';
 
 // Panzoom constants
 export const ZOOM_MIN = 0.25; // 25% - allows fitting 6+ large racks
@@ -276,26 +285,18 @@ function zoomToDevice(rack: Rack, deviceIndex: number, deviceTypes: import('$lib
 	const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
 	if (!deviceType) return;
 
-	// Rack rendering constants (must match canvas.ts and Rack.svelte)
-	const U_HEIGHT = 22;
-	const RACK_WIDTH = 220;
-	const RAIL_WIDTH = 17;
-	const RACK_PADDING = 18;
-	const DUAL_VIEW_EXTRA_HEIGHT = 56;
-	const RACK_ROW_PADDING = 16;
-	const DUAL_VIEW_GAP = 24;
-
 	// Calculate device position in SVG coordinates
 	// Device Y position: from top of SVG viewBox
 	const rackHeight = rack.height;
-	const deviceYInRack = (rackHeight - device.position - deviceType.u_height + 1) * U_HEIGHT;
-	const deviceHeight = deviceType.u_height * U_HEIGHT;
+	const deviceYInRack = (rackHeight - device.position - deviceType.u_height + 1) * U_HEIGHT_PX;
+	const deviceHeight = deviceType.u_height * U_HEIGHT_PX;
 
 	// Device absolute Y: includes rack padding, top rail, and dual-view extra height
-	const deviceAbsY = RACK_ROW_PADDING + DUAL_VIEW_EXTRA_HEIGHT + RACK_PADDING + RAIL_WIDTH + deviceYInRack;
+	const deviceAbsY =
+		RACK_ROW_PADDING + DUAL_VIEW_EXTRA_HEIGHT + BASE_RACK_PADDING + RAIL_WIDTH + deviceYInRack;
 
 	// Device X position: centered between two rack views in dual-view mode
-	const dualViewWidth = RACK_WIDTH * 2 + DUAL_VIEW_GAP;
+	const dualViewWidth = BASE_RACK_WIDTH * 2 + DUAL_VIEW_GAP;
 	const deviceAbsX = RACK_ROW_PADDING + dualViewWidth / 2;
 
 	// Get viewport dimensions

--- a/src/lib/utils/canvas.ts
+++ b/src/lib/utils/canvas.ts
@@ -5,17 +5,18 @@
  */
 
 import type { Rack } from '$lib/types';
-
-// Rack rendering constants (must match Rack.svelte and Canvas.svelte)
-const U_HEIGHT = 22;
-const RACK_WIDTH = 220;
-const RAIL_WIDTH = 17; // Width of rails and top/bottom bars
-const RACK_PADDING = 18; // Space at top for rack name (must match Rack.svelte)
-const RACK_GAP = 24; // Gap between racks (unused in v0.1.1 single-rack mode)
-const RACK_ROW_PADDING = 16; // Padding around rack-row
-const DUAL_VIEW_GAP = 24; // Gap between front/rear views in dual-view mode (--spacing-lg)
-// Dual-view wrapper adds extra height: padding (12+12) + gap (8) + name (~20) + margin (4) = ~56px
-const DUAL_VIEW_EXTRA_HEIGHT = 56;
+import {
+	U_HEIGHT_PX,
+	BASE_RACK_WIDTH,
+	RAIL_WIDTH,
+	BASE_RACK_PADDING,
+	RACK_GAP,
+	RACK_ROW_PADDING,
+	DUAL_VIEW_GAP,
+	DUAL_VIEW_EXTRA_HEIGHT,
+	FIT_ALL_PADDING,
+	FIT_ALL_MAX_ZOOM
+} from '$lib/constants/layout';
 
 /**
  * Bounding box interface
@@ -46,15 +47,7 @@ export interface FitAllResult {
 	panY: number;
 }
 
-/**
- * Padding around content for fit-all calculation (in pixels)
- */
-const FIT_ALL_PADDING = 48;
-
-/**
- * Maximum zoom level for fit-all
- */
-const FIT_ALL_MAX_ZOOM = 2;
+// FIT_ALL_PADDING and FIT_ALL_MAX_ZOOM imported from layout constants
 
 /**
  * Calculate the bounding box that encompasses all racks.
@@ -169,15 +162,15 @@ export function racksToPositions(racks: Rack[]): RackPosition[] {
 	const sorted = [...racks].sort((a, b) => a.position - b.position);
 
 	// Calculate total rendered height
-	// SVG viewBoxHeight = RACK_PADDING + RAIL_WIDTH * 2 + rack.height * U_HEIGHT
+	// SVG viewBoxHeight = BASE_RACK_PADDING + RAIL_WIDTH * 2 + rack.height * U_HEIGHT_PX
 	// (rack name padding + top bar + U slots + bottom bar)
 	// Plus dual-view wrapper extra height (v0.4)
 	const getRackHeight = (rack: Rack) =>
-		RACK_PADDING + RAIL_WIDTH * 2 + rack.height * U_HEIGHT + DUAL_VIEW_EXTRA_HEIGHT;
+		BASE_RACK_PADDING + RAIL_WIDTH * 2 + rack.height * U_HEIGHT_PX + DUAL_VIEW_EXTRA_HEIGHT;
 
 	// v0.4: Dual-view mode shows two racks side by side
-	// Visual width = 2 * RACK_WIDTH + DUAL_VIEW_GAP
-	const getDualViewWidth = () => RACK_WIDTH * 2 + DUAL_VIEW_GAP;
+	// Visual width = 2 * BASE_RACK_WIDTH + DUAL_VIEW_GAP
+	const getDualViewWidth = () => BASE_RACK_WIDTH * 2 + DUAL_VIEW_GAP;
 
 	// Find max height for vertical alignment (single value in v0.1.1)
 	const maxHeight = Math.max(...sorted.map(getRackHeight));

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -12,22 +12,28 @@ import type {
 } from '$lib/types';
 import type { ImageStoreMap } from '$lib/types/images';
 import { getBlockedSlots } from './blocked-slots';
+import {
+	U_HEIGHT_PX,
+	BASE_RACK_WIDTH,
+	RAIL_WIDTH,
+	RACK_PADDING_HIDDEN
+} from '$lib/constants/layout';
 
 // Note: jsPDF is imported dynamically in exportAsPDF() to avoid loading
 // the large jsPDF + html2canvas bundle (~200KB) on app startup.
 // See issue #68 for details.
 
-// Constants matching Rack.svelte dimensions
-const U_HEIGHT = 22;
-const RACK_WIDTH = 220;
-const RAIL_WIDTH = 17;
-const RACK_PADDING = 4;
+// Aliases for export context (export uses hidden padding since view labels show rack name)
+const U_HEIGHT = U_HEIGHT_PX;
+const RACK_WIDTH = BASE_RACK_WIDTH;
+const RACK_PADDING = RACK_PADDING_HIDDEN;
 const RACK_GAP = 40;
 const LEGEND_PADDING = 20;
 const LEGEND_ITEM_HEIGHT = 24;
 const EXPORT_PADDING = 20;
 const RACK_NAME_HEIGHT = 18; // Space for rack name above rack
 const VIEW_LABEL_HEIGHT = 15; // Space for FRONT/REAR labels
+const RACK_BOTTOM_PADDING = 2; // Visual breathing room below bottom rail
 
 // QR Code export constants
 const QR_SIZE = 150; // Size of QR code in pixels for screen exports
@@ -386,7 +392,13 @@ export function generateExportSVG(
 		: isDualView
 			? VIEW_LABEL_HEIGHT // Just view labels
 			: 0;
-	const rackAreaHeight = maxRackHeight * U_HEIGHT + RACK_PADDING * 2 + headerSpace;
+	// Rack internal height: top padding + top rail + U slots + bottom rail + bottom padding
+	const rackAreaHeight =
+		maxRackHeight * U_HEIGHT +
+		RACK_PADDING +
+		RAIL_WIDTH * 2 +
+		RACK_BOTTOM_PADDING +
+		headerSpace;
 	const legendWidth = includeLegend ? 180 : 0;
 	const legendHeight = includeLegend
 		? usedDevices.length * LEGEND_ITEM_HEIGHT + LEGEND_PADDING * 2


### PR DESCRIPTION
## Summary
- Created centralized `src/lib/constants/layout.ts` with all rack rendering constants
- Updated 5 files to import from shared constants file
- Fixed export bottom padding (was clipping bottom rail)

## Files Changed
- `src/lib/constants/layout.ts`: New file with all layout constants and helper functions
- `src/lib/utils/canvas.ts`: Now imports from centralized file
- `src/lib/utils/export.ts`: Imports core constants + adds 2px bottom padding
- `src/lib/stores/canvas.svelte.ts`: Now imports from centralized file
- `src/lib/components/WelcomeScreen.svelte`: Now imports from centralized file
- `src/lib/components/RackDevice.svelte`: Now imports RAIL_WIDTH from centralized file

## Constants Organization
**Core (shared):**
- U_HEIGHT_PX, RAIL_WIDTH, BASE_RACK_WIDTH
- BASE_RACK_PADDING, RACK_PADDING_HIDDEN

**Canvas:**
- RACK_ROW_PADDING, DUAL_VIEW_GAP, DUAL_VIEW_EXTRA_HEIGHT
- FIT_ALL_PADDING, FIT_ALL_MAX_ZOOM

**Export-specific (remain in export.ts):**
- RACK_GAP (40 for export vs 24 for canvas)
- QR_SIZE, LEGEND_ITEM_HEIGHT, etc.

## Test Plan
- [x] All 2371 unit tests pass
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual: verify export doesn't clip bottom of rack

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)