### PR TITLE
fix: clean up images when device type is deleted (#147)

### DIFF
--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -25,6 +25,7 @@ import { findDeviceType } from '$lib/utils/device-lookup';
 import { debug } from '$lib/utils/debug';
 import { generateId } from '$lib/utils/device';
 import { getHistoryStore } from './history.svelte';
+import { getImageStore } from './images.svelte';
 import {
 	createAddDeviceTypeCommand,
 	createUpdateDeviceTypeCommand,
@@ -548,6 +549,9 @@ function removeDeviceTypeRaw(slug: string): void {
 			devices: layout.rack.devices.filter((d) => d.device_type !== slug)
 		}
 	};
+
+	// Clean up associated images to prevent memory leaks
+	getImageStore().removeAllDeviceImages(slug);
 }
 
 /**

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getLayoutStore, resetLayoutStore } from '$lib/stores/layout.svelte';
+import { getImageStore, resetImageStore } from '$lib/stores/images.svelte';
 import type { Layout } from '$lib/types';
 import { VERSION } from '$lib/version';
 
@@ -357,6 +358,40 @@ describe('Layout Store (v0.2)', () => {
 			store.markClean();
 			store.deleteDeviceType(deviceType.slug);
 			expect(store.isDirty).toBe(true);
+		});
+
+		it('cleans up associated images from image store (Issue #147)', () => {
+			const store = getLayoutStore();
+			resetImageStore();
+			const imageStore = getImageStore();
+
+			const deviceType = store.addDeviceType({
+				name: 'Device With Image',
+				u_height: 2,
+				category: 'server',
+				colour: '#4A90D9'
+			});
+
+			// Add images for the device type
+			imageStore.setDeviceImage(deviceType.slug, 'front', {
+				dataUrl: 'data:image/png;base64,test',
+				filename: 'front.png'
+			});
+			imageStore.setDeviceImage(deviceType.slug, 'rear', {
+				dataUrl: 'data:image/png;base64,test',
+				filename: 'rear.png'
+			});
+
+			// Verify images exist
+			expect(imageStore.hasImage(deviceType.slug, 'front')).toBe(true);
+			expect(imageStore.hasImage(deviceType.slug, 'rear')).toBe(true);
+
+			// Delete the device type
+			store.deleteDeviceType(deviceType.slug);
+
+			// Images should be cleaned up
+			expect(imageStore.hasImage(deviceType.slug, 'front')).toBe(false);
+			expect(imageStore.hasImage(deviceType.slug, 'rear')).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- When a device type is deleted, its associated images are now automatically removed from the image store
- Prevents memory leaks from orphaned images

## Files Changed
- `src/lib/stores/layout.svelte.ts`: Added image cleanup call in `removeDeviceTypeRaw`
- `src/tests/layout-store.test.ts`: Added test case for image cleanup behavior

## Test plan
- [x] Existing tests pass
- [x] New test verifies images are cleaned up on device type deletion
- [x] Build succeeds

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)