### PR TITLE
chore: switch selection store to UUID-based tracking (#148)

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -147,14 +147,14 @@
 	}
 
 	function handleDeviceSelect(event: CustomEvent<{ slug: string; position: number }>) {
-		// Find the device index in the rack (single-rack mode)
+		// Find the device by slug and position, then select by ID (UUID-based tracking)
 		const currentRack = layoutStore.rack;
 		if (currentRack) {
-			const deviceIndex = currentRack.devices.findIndex(
+			const device = currentRack.devices.find(
 				(d) => d.device_type === event.detail.slug && d.position === event.detail.position
 			);
-			if (deviceIndex !== -1) {
-				selectionStore.selectDevice(RACK_ID, deviceIndex, event.detail.slug);
+			if (device) {
+				selectionStore.selectDevice(RACK_ID, device.id);
 			}
 		}
 		ondeviceselect?.(event);
@@ -220,10 +220,10 @@
 				<RackDualView
 					{rack}
 					deviceLibrary={layoutStore.device_types}
-					selected={selectionStore.selectedType === 'rack' && selectionStore.selectedId === RACK_ID}
-					selectedDeviceIndex={selectionStore.selectedType === 'device' &&
+					selected={selectionStore.selectedType === 'rack' && selectionStore.selectedRackId === RACK_ID}
+					selectedDeviceId={selectionStore.selectedType === 'device' &&
 					selectionStore.selectedRackId === RACK_ID
-						? selectionStore.selectedDeviceIndex
+						? selectionStore.selectedDeviceId
 						: null}
 					displayMode={uiStore.displayMode}
 					showLabelsOnImages={uiStore.showLabelsOnImages}

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -225,14 +225,18 @@
 	 */
 	function moveSelectedDevice(direction: number, stepOverride?: number) {
 		if (!selectionStore.isDeviceSelected) return;
-		if (selectionStore.selectedRackId === null || selectionStore.selectedDeviceIndex === null)
+		if (selectionStore.selectedRackId === null || selectionStore.selectedDeviceId === null)
 			return;
 
 		// Single-rack mode
 		const rack = layoutStore.rack;
 		if (!rack) return;
 
-		const placedDevice = rack.devices[selectionStore.selectedDeviceIndex];
+		// Get device index from ID (UUID-based tracking)
+		const deviceIndex = selectionStore.getSelectedDeviceIndex(rack.devices);
+		if (deviceIndex === null) return;
+
+		const placedDevice = rack.devices[deviceIndex];
 		if (!placedDevice) return;
 
 		const device = layoutStore.device_types.find((d) => d.slug === placedDevice.device_type);
@@ -253,7 +257,7 @@
 				layoutStore.device_types,
 				device.u_height,
 				newPosition,
-				selectionStore.selectedDeviceIndex!,
+				deviceIndex,
 				placedDevice.face,
 				isFullDepth
 			);
@@ -262,7 +266,7 @@
 				// Found a valid position, move there
 				layoutStore.moveDevice(
 					selectionStore.selectedRackId!,
-					selectionStore.selectedDeviceIndex!,
+					deviceIndex,
 					newPosition
 				);
 				return;
@@ -288,9 +292,9 @@
 	 * Duplicate the selected rack
 	 */
 	function duplicateSelectedRack() {
-		if (!selectionStore.isRackSelected || !selectionStore.selectedId) return;
+		if (!selectionStore.isRackSelected || !selectionStore.selectedRackId) return;
 
-		const result = layoutStore.duplicateRack(selectionStore.selectedId);
+		const result = layoutStore.duplicateRack(selectionStore.selectedRackId);
 		if (result.error) {
 			toastStore.showToast(result.error, 'error');
 		}

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -25,8 +25,8 @@
 		rack: RackType;
 		deviceLibrary: DeviceType[];
 		selected: boolean;
-		/** Index of the selected device in the rack's devices array (null if no device selected) */
-		selectedDeviceIndex?: number | null;
+		/** ID of the selected device (UUID-based tracking, null if no device selected) */
+		selectedDeviceId?: string | null;
 		displayMode?: DisplayMode;
 		showLabelsOnImages?: boolean;
 		/** Filter devices by face - when set, overrides rack.view for filtering */
@@ -57,7 +57,7 @@
 		rack,
 		deviceLibrary,
 		selected,
-		selectedDeviceIndex = null,
+		selectedDeviceId = null,
 		displayMode = 'label',
 		showLabelsOnImages = false,
 		faceFilter,
@@ -514,7 +514,7 @@
 						rackHeight={rack.height}
 						rackId={RACK_ID}
 						deviceIndex={originalIndex}
-						selected={selectedDeviceIndex === originalIndex}
+						selected={selectedDeviceId === placedDevice.id}
 						uHeight={U_HEIGHT}
 						rackWidth={RACK_WIDTH}
 						{displayMode}

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -14,8 +14,8 @@
 		rack: RackType;
 		deviceLibrary: DeviceType[];
 		selected: boolean;
-		/** Index of the selected device in the rack's devices array */
-		selectedDeviceIndex?: number | null;
+		/** ID of the selected device (UUID-based tracking) */
+		selectedDeviceId?: string | null;
 		displayMode?: DisplayMode;
 		showLabelsOnImages?: boolean;
 		/** Party mode visual effects active */
@@ -47,7 +47,7 @@
 		rack,
 		deviceLibrary,
 		selected,
-		selectedDeviceIndex = null,
+		selectedDeviceId = null,
 		displayMode = 'label',
 		showLabelsOnImages = false,
 		partyMode = false,
@@ -122,7 +122,7 @@
 				{rack}
 				{deviceLibrary}
 				selected={false}
-				{selectedDeviceIndex}
+				{selectedDeviceId}
 				{displayMode}
 				{showLabelsOnImages}
 				{partyMode}
@@ -143,7 +143,7 @@
 				{rack}
 				{deviceLibrary}
 				selected={false}
-				{selectedDeviceIndex}
+				{selectedDeviceId}
 				{displayMode}
 				{showLabelsOnImages}
 				{partyMode}

--- a/src/tests/EditPanel.test.ts
+++ b/src/tests/EditPanel.test.ts
@@ -59,8 +59,9 @@ describe('EditPanel Component', () => {
 			});
 			layoutStore.placeDevice(RACK_ID, device.slug, 1);
 
-			// Select the device
-			selectionStore.selectDevice(RACK_ID, 0, device.slug);
+			// Select the device by ID
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 			const panel = screen.getByRole('complementary');
@@ -188,7 +189,8 @@ describe('EditPanel Component', () => {
 				comments: 'Some notes'
 			});
 			layoutStore.placeDevice(RACK_ID, device.slug, 5);
-			selectionStore.selectDevice(RACK_ID, 0, device.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -218,7 +220,8 @@ describe('EditPanel Component', () => {
 				notes: 'Important server notes'
 			});
 			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			selectionStore.selectDevice(RACK_ID, 0, device.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -238,7 +241,8 @@ describe('EditPanel Component', () => {
 				colour: '#4A90D9'
 			});
 			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			selectionStore.selectDevice(RACK_ID, 0, device.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -260,7 +264,8 @@ describe('EditPanel Component', () => {
 				colour: '#4A90D9'
 			});
 			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			selectionStore.selectDevice(RACK_ID, 0, device.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -285,7 +290,8 @@ describe('EditPanel Component', () => {
 			};
 			layoutStore.layout.device_types.push(deviceType);
 			layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
-			selectionStore.selectDevice(RACK_ID, 0, deviceType.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -311,7 +317,8 @@ describe('EditPanel Component', () => {
 			};
 			layoutStore.layout.device_types.push(deviceType);
 			layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
-			selectionStore.selectDevice(RACK_ID, 0, deviceType.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -336,7 +343,8 @@ describe('EditPanel Component', () => {
 			};
 			layoutStore.layout.device_types.push(deviceType);
 			layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
-			selectionStore.selectDevice(RACK_ID, 0, deviceType.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -362,7 +370,8 @@ describe('EditPanel Component', () => {
 			};
 			layoutStore.layout.device_types.push(deviceType);
 			layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
-			selectionStore.selectDevice(RACK_ID, 0, deviceType.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -388,7 +397,8 @@ describe('EditPanel Component', () => {
 			colour: '#4A90D9'
 		});
 		layoutStore.placeDevice(RACK_ID, device.slug, 1);
-		selectionStore.selectDevice(RACK_ID, 0, device.slug);
+		const deviceId = layoutStore.rack!.devices[0]!.id;
+		selectionStore.selectDevice(RACK_ID, deviceId);
 
 		const { getByLabelText } = render(EditPanel);
 		expect(getByLabelText(/mounted face/i)).toBeTruthy();
@@ -407,7 +417,8 @@ describe('EditPanel Component', () => {
 			colour: '#4A90D9'
 		});
 		layoutStore.placeDevice(RACK_ID, device.slug, 1);
-		selectionStore.selectDevice(RACK_ID, 0, device.slug);
+		const deviceId = layoutStore.rack!.devices[0]!.id;
+		selectionStore.selectDevice(RACK_ID, deviceId);
 
 		const { getByRole } = render(EditPanel);
 		const select = getByRole('combobox', { name: /mounted face/i });

--- a/src/tests/EditPanelLayout.test.ts
+++ b/src/tests/EditPanelLayout.test.ts
@@ -168,7 +168,8 @@ describe('EditPanel Visual Hierarchy', () => {
 				colour: '#2563eb'
 			});
 			layoutStore.placeDevice(RACK_ID, device.slug, 10);
-			selectionStore.selectDevice(RACK_ID, 0, device.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -190,7 +191,8 @@ describe('EditPanel Visual Hierarchy', () => {
 				colour: '#2563eb'
 			});
 			layoutStore.placeDevice(RACK_ID, device.slug, 10);
-			selectionStore.selectDevice(RACK_ID, 0, device.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 
@@ -213,7 +215,8 @@ describe('EditPanel Visual Hierarchy', () => {
 				colour: '#2563eb'
 			});
 			layoutStore.placeDevice(RACK_ID, device.slug, 10);
-			selectionStore.selectDevice(RACK_ID, 0, device.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(RACK_ID, deviceId);
 
 			render(EditPanel);
 

--- a/src/tests/RackVisuals.test.ts
+++ b/src/tests/RackVisuals.test.ts
@@ -193,7 +193,7 @@ describe('Rack Visual Enhancements', () => {
 	});
 
 	describe('Device Selection', () => {
-		it('only the device at the selected index shows selection highlight, not all devices of same type', () => {
+		it('only the device with selected ID shows selection highlight, not all devices of same type', () => {
 			// Create two devices with the same device_type (same device type)
 			const deviceType: DeviceType = {
 				slug: 'device-type-1',
@@ -206,18 +206,18 @@ describe('Rack Visual Enhancements', () => {
 			const rackWithDevices: RackType = {
 				...testRack,
 				devices: [
-					{ device_type: 'device-type-1', position: 5, face: 'front' },
-					{ device_type: 'device-type-1', position: 10, face: 'front' } // Same device_type, different position
+					{ id: 'uuid-1', device_type: 'device-type-1', position: 5, face: 'front' },
+					{ id: 'uuid-2', device_type: 'device-type-1', position: 10, face: 'front' } // Same device_type, different position
 				]
 			};
 
-			// Render with only device at index 0 selected
+			// Render with only the first device selected by ID
 			const { container } = render(Rack, {
 				props: {
 					rack: rackWithDevices,
 					deviceLibrary: [deviceType],
 					selected: false,
-					selectedDeviceIndex: 0 // Select the first device only
+					selectedDeviceId: 'uuid-1' // Select the first device only
 				}
 			});
 
@@ -232,7 +232,7 @@ describe('Rack Visual Enhancements', () => {
 			expect(selectionOutlines.length).toBe(1);
 		});
 
-		it('no devices are selected when selectedDeviceIndex is null', () => {
+		it('no devices are selected when selectedDeviceId is null', () => {
 			const deviceType: DeviceType = {
 				slug: 'device-type-1',
 				model: 'Test Server',
@@ -243,8 +243,8 @@ describe('Rack Visual Enhancements', () => {
 			const rackWithDevices: RackType = {
 				...testRack,
 				devices: [
-					{ device_type: 'device-type-1', position: 5, face: 'front' },
-					{ device_type: 'device-type-1', position: 10, face: 'front' }
+					{ id: 'uuid-1', device_type: 'device-type-1', position: 5, face: 'front' },
+					{ id: 'uuid-2', device_type: 'device-type-1', position: 10, face: 'front' }
 				]
 			};
 
@@ -253,7 +253,7 @@ describe('Rack Visual Enhancements', () => {
 					rack: rackWithDevices,
 					deviceLibrary: [deviceType],
 					selected: false,
-					selectedDeviceIndex: null
+					selectedDeviceId: null
 				}
 			});
 

--- a/src/tests/keyboard.test.ts
+++ b/src/tests/keyboard.test.ts
@@ -165,8 +165,9 @@ describe('KeyboardHandler Component', () => {
 			const rackId = 'rack-0';
 			layoutStore.placeDevice(rackId, deviceType.slug, 5);
 
-			// Select the device
-			selectionStore.selectDevice(rackId, 0, deviceType.slug);
+			// Select the device by ID
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(rackId, deviceId);
 
 			render(KeyboardHandler);
 
@@ -192,8 +193,9 @@ describe('KeyboardHandler Component', () => {
 			const rackId = 'rack-0';
 			layoutStore.placeDevice(rackId, deviceType.slug, 5);
 
-			// Select the device
-			selectionStore.selectDevice(rackId, 0, deviceType.slug);
+			// Select the device by ID
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(rackId, deviceId);
 
 			render(KeyboardHandler);
 
@@ -219,8 +221,9 @@ describe('KeyboardHandler Component', () => {
 			const rackId = 'rack-0';
 			layoutStore.placeDevice(rackId, deviceType.slug, 1);
 
-			// Select the device
-			selectionStore.selectDevice(rackId, 0, deviceType.slug);
+			// Select the device by ID
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice(rackId, deviceId);
 
 			render(KeyboardHandler);
 
@@ -618,7 +621,8 @@ describe('KeyboardHandler Component', () => {
 				colour: CATEGORY_COLOURS.server
 			});
 			layoutStore.placeDevice('rack-0', deviceType.slug, 5);
-			selectionStore.selectDevice('rack-0', 0, deviceType.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice('rack-0', deviceId);
 
 			render(KeyboardHandler);
 
@@ -641,7 +645,8 @@ describe('KeyboardHandler Component', () => {
 				colour: CATEGORY_COLOURS.server
 			});
 			layoutStore.placeDevice('rack-0', deviceType.slug, 5);
-			selectionStore.selectDevice('rack-0', 0, deviceType.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice('rack-0', deviceId);
 
 			render(KeyboardHandler);
 
@@ -664,7 +669,8 @@ describe('KeyboardHandler Component', () => {
 				colour: CATEGORY_COLOURS.server
 			});
 			layoutStore.placeDevice('rack-0', deviceType.slug, 1);
-			selectionStore.selectDevice('rack-0', 0, deviceType.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice('rack-0', deviceId);
 
 			render(KeyboardHandler);
 
@@ -688,10 +694,11 @@ describe('KeyboardHandler Component', () => {
 
 			// Place two adjacent devices
 			layoutStore.placeDevice('rack-0', deviceType.slug, 5);
+			const firstDeviceId = layoutStore.rack!.devices[0]!.id;
 			layoutStore.placeDevice('rack-0', deviceType.slug, 6);
 
-			// Select the first device
-			selectionStore.selectDevice('rack-0', 0, deviceType.slug);
+			// Select the first device by ID
+			selectionStore.selectDevice('rack-0', firstDeviceId);
 
 			render(KeyboardHandler);
 
@@ -716,7 +723,8 @@ describe('KeyboardHandler Component', () => {
 				colour: CATEGORY_COLOURS.server
 			});
 			layoutStore.placeDevice('rack-0', deviceType.slug, 10);
-			selectionStore.selectDevice('rack-0', 0, deviceType.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice('rack-0', deviceId);
 
 			render(KeyboardHandler);
 
@@ -741,7 +749,8 @@ describe('KeyboardHandler Component', () => {
 				colour: CATEGORY_COLOURS.server
 			});
 			layoutStore.placeDevice('rack-0', deviceType.slug, 10);
-			selectionStore.selectDevice('rack-0', 0, deviceType.slug);
+			const deviceId = layoutStore.rack!.devices[0]!.id;
+			selectionStore.selectDevice('rack-0', deviceId);
 
 			render(KeyboardHandler);
 
@@ -766,11 +775,12 @@ describe('KeyboardHandler Component', () => {
 
 			// Place a device at position 5
 			layoutStore.placeDevice('rack-0', serverType.slug, 5);
+			const firstDeviceId = layoutStore.rack!.devices[0]!.id;
 			// Place another device at position 6 (blocking)
 			layoutStore.placeDevice('rack-0', serverType.slug, 6);
 
-			// Select the first device (at position 5)
-			selectionStore.selectDevice('rack-0', 0, serverType.slug);
+			// Select the first device (at position 5) by ID
+			selectionStore.selectDevice('rack-0', firstDeviceId);
 
 			render(KeyboardHandler);
 

--- a/src/tests/selection-store.test.ts
+++ b/src/tests/selection-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getSelectionStore, resetSelectionStore } from '$lib/stores/selection.svelte';
+import type { PlacedDevice } from '$lib/types';
 
 describe('Selection Store', () => {
 	beforeEach(() => {
@@ -9,10 +10,9 @@ describe('Selection Store', () => {
 	describe('initial state', () => {
 		it('has no selection', () => {
 			const store = getSelectionStore();
-			expect(store.selectedId).toBeNull();
 			expect(store.selectedType).toBeNull();
 			expect(store.selectedRackId).toBeNull();
-			expect(store.selectedDeviceIndex).toBeNull();
+			expect(store.selectedDeviceId).toBeNull();
 		});
 
 		it('hasSelection returns false', () => {
@@ -32,22 +32,22 @@ describe('Selection Store', () => {
 	});
 
 	describe('selectRack', () => {
-		it('sets selectedId and selectedType to rack', () => {
+		it('sets selectedRackId and selectedType to rack', () => {
 			const store = getSelectionStore();
 			store.selectRack('rack-123');
-			expect(store.selectedId).toBe('rack-123');
+			expect(store.selectedRackId).toBe('rack-123');
 			expect(store.selectedType).toBe('rack');
 		});
 
 		it('clears previous device selection', () => {
 			const store = getSelectionStore();
-			store.selectDevice('rack-1', 0, 'device-123');
+			store.selectDevice('rack-1', 'device-uuid-123');
 			expect(store.selectedType).toBe('device');
 
 			store.selectRack('rack-2');
 			expect(store.selectedType).toBe('rack');
-			expect(store.selectedRackId).toBeNull();
-			expect(store.selectedDeviceIndex).toBeNull();
+			expect(store.selectedRackId).toBe('rack-2');
+			expect(store.selectedDeviceId).toBeNull();
 		});
 
 		it('hasSelection returns true when rack selected', () => {
@@ -70,13 +70,12 @@ describe('Selection Store', () => {
 	});
 
 	describe('selectDevice', () => {
-		it('sets selectedId, selectedType, selectedRackId, and selectedDeviceIndex', () => {
+		it('sets selectedDeviceId, selectedType, and selectedRackId', () => {
 			const store = getSelectionStore();
-			store.selectDevice('rack-1', 5, 'device-123');
-			expect(store.selectedId).toBe('device-123');
+			store.selectDevice('rack-1', 'device-uuid-123');
+			expect(store.selectedDeviceId).toBe('device-uuid-123');
 			expect(store.selectedType).toBe('device');
 			expect(store.selectedRackId).toBe('rack-1');
-			expect(store.selectedDeviceIndex).toBe(5);
 		});
 
 		it('clears previous rack selection', () => {
@@ -84,26 +83,26 @@ describe('Selection Store', () => {
 			store.selectRack('rack-1');
 			expect(store.selectedType).toBe('rack');
 
-			store.selectDevice('rack-2', 0, 'device-123');
+			store.selectDevice('rack-2', 'device-uuid-123');
 			expect(store.selectedType).toBe('device');
-			expect(store.selectedId).toBe('device-123');
+			expect(store.selectedDeviceId).toBe('device-uuid-123');
 		});
 
 		it('hasSelection returns true when device selected', () => {
 			const store = getSelectionStore();
-			store.selectDevice('rack-1', 0, 'device-123');
+			store.selectDevice('rack-1', 'device-uuid-123');
 			expect(store.hasSelection).toBe(true);
 		});
 
 		it('isRackSelected returns false when device selected', () => {
 			const store = getSelectionStore();
-			store.selectDevice('rack-1', 0, 'device-123');
+			store.selectDevice('rack-1', 'device-uuid-123');
 			expect(store.isRackSelected).toBe(false);
 		});
 
 		it('isDeviceSelected returns true when device selected', () => {
 			const store = getSelectionStore();
-			store.selectDevice('rack-1', 0, 'device-123');
+			store.selectDevice('rack-1', 'device-uuid-123');
 			expect(store.isDeviceSelected).toBe(true);
 		});
 	});
@@ -111,14 +110,13 @@ describe('Selection Store', () => {
 	describe('clearSelection', () => {
 		it('resets all selection state', () => {
 			const store = getSelectionStore();
-			store.selectDevice('rack-1', 0, 'device-123');
+			store.selectDevice('rack-1', 'device-uuid-123');
 			expect(store.hasSelection).toBe(true);
 
 			store.clearSelection();
-			expect(store.selectedId).toBeNull();
 			expect(store.selectedType).toBeNull();
 			expect(store.selectedRackId).toBeNull();
-			expect(store.selectedDeviceIndex).toBeNull();
+			expect(store.selectedDeviceId).toBeNull();
 		});
 
 		it('hasSelection returns false after clearing', () => {
@@ -126,6 +124,39 @@ describe('Selection Store', () => {
 			store.selectRack('rack-1');
 			store.clearSelection();
 			expect(store.hasSelection).toBe(false);
+		});
+	});
+
+	describe('getSelectedDeviceIndex', () => {
+		it('returns the index of the selected device in the array', () => {
+			const store = getSelectionStore();
+			const devices: PlacedDevice[] = [
+				{ id: 'uuid-1', device_type: 'server', position: 1, face: 'front' },
+				{ id: 'uuid-2', device_type: 'switch', position: 5, face: 'front' },
+				{ id: 'uuid-3', device_type: 'server', position: 10, face: 'rear' }
+			];
+
+			store.selectDevice('rack-1', 'uuid-2');
+			expect(store.getSelectedDeviceIndex(devices)).toBe(1);
+		});
+
+		it('returns null when no device is selected', () => {
+			const store = getSelectionStore();
+			const devices: PlacedDevice[] = [
+				{ id: 'uuid-1', device_type: 'server', position: 1, face: 'front' }
+			];
+
+			expect(store.getSelectedDeviceIndex(devices)).toBeNull();
+		});
+
+		it('returns null when selected device is not in array', () => {
+			const store = getSelectionStore();
+			const devices: PlacedDevice[] = [
+				{ id: 'uuid-1', device_type: 'server', position: 1, face: 'front' }
+			];
+
+			store.selectDevice('rack-1', 'uuid-not-found');
+			expect(store.getSelectedDeviceIndex(devices)).toBeNull();
 		});
 	});
 
@@ -138,7 +169,7 @@ describe('Selection Store', () => {
 
 		it('returns true when device selected', () => {
 			const store = getSelectionStore();
-			store.selectDevice('rack-1', 0, 'device-1');
+			store.selectDevice('rack-1', 'device-uuid-1');
 			expect(store.hasSelection).toBe(true);
 		});
 

--- a/src/tests/selection.test.ts
+++ b/src/tests/selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getSelectionStore, resetSelectionStore } from '$lib/stores/selection.svelte';
+import type { PlacedDevice } from '$lib/types';
 
 describe('Selection Store', () => {
 	beforeEach(() => {
@@ -7,77 +8,102 @@ describe('Selection Store', () => {
 	});
 
 	describe('device selection', () => {
-		it('stores deviceIndex when selecting a device', () => {
+		it('stores deviceId when selecting a device', () => {
 			const store = getSelectionStore();
 
-			store.selectDevice('rack-1', 0, 'device-type-a');
+			store.selectDevice('rack-1', 'device-uuid-1');
 
-			expect(store.selectedDeviceIndex).toBe(0);
+			expect(store.selectedDeviceId).toBe('device-uuid-1');
 			expect(store.selectedRackId).toBe('rack-1');
 			expect(store.selectedType).toBe('device');
 		});
 
-		it('selects by index, allowing multiple devices of same type to be distinguished', () => {
+		it('selects by UUID, allowing multiple devices of same type to be distinguished', () => {
 			const store = getSelectionStore();
 
-			// Two devices with the same device_type at different indices
-			// Select the first one (index 0)
-			store.selectDevice('rack-1', 0, 'device-type-a');
+			// Two devices with the same device_type but different UUIDs
+			// Select the first one
+			store.selectDevice('rack-1', 'uuid-device-a1');
 
-			expect(store.selectedDeviceIndex).toBe(0);
+			expect(store.selectedDeviceId).toBe('uuid-device-a1');
 			expect(store.selectedRackId).toBe('rack-1');
 
-			// Select the second one (index 1)
-			store.selectDevice('rack-1', 1, 'device-type-a');
+			// Select the second one
+			store.selectDevice('rack-1', 'uuid-device-a2');
 
-			expect(store.selectedDeviceIndex).toBe(1);
+			expect(store.selectedDeviceId).toBe('uuid-device-a2');
 			expect(store.selectedRackId).toBe('rack-1');
 		});
 
 		it('clears selection correctly', () => {
 			const store = getSelectionStore();
 
-			store.selectDevice('rack-1', 0, 'device-type-a');
+			store.selectDevice('rack-1', 'device-uuid-1');
 			store.clearSelection();
 
-			expect(store.selectedDeviceIndex).toBeNull();
+			expect(store.selectedDeviceId).toBeNull();
 			expect(store.selectedRackId).toBeNull();
 			expect(store.selectedType).toBeNull();
-			expect(store.selectedId).toBeNull();
 		});
 
-		it('selecting a rack clears device index', () => {
+		it('selecting a rack clears device id', () => {
 			const store = getSelectionStore();
 
-			store.selectDevice('rack-1', 0, 'device-type-a');
+			store.selectDevice('rack-1', 'device-uuid-1');
 			store.selectRack('rack-1');
 
-			expect(store.selectedDeviceIndex).toBeNull();
+			expect(store.selectedDeviceId).toBeNull();
 			expect(store.selectedType).toBe('rack');
 		});
 	});
 
 	describe('isDeviceSelected helper', () => {
-		it('returns true only for the exact device at the selected index', () => {
+		it('returns true only for the exact device with the selected UUID', () => {
 			const store = getSelectionStore();
 
-			// Select device at index 0 in rack-1
-			store.selectDevice('rack-1', 0, 'device-type-a');
+			// Select device with uuid-1 in rack-1
+			store.selectDevice('rack-1', 'uuid-1');
 
 			// Helper function to check if a specific device is selected
-			const isSelected = (rackId: string, deviceIndex: number) =>
+			const isSelected = (rackId: string, deviceId: string) =>
 				store.selectedType === 'device' &&
 				store.selectedRackId === rackId &&
-				store.selectedDeviceIndex === deviceIndex;
+				store.selectedDeviceId === deviceId;
 
-			// Device at index 0 should be selected
-			expect(isSelected('rack-1', 0)).toBe(true);
+			// Device with uuid-1 should be selected
+			expect(isSelected('rack-1', 'uuid-1')).toBe(true);
 
-			// Device at index 1 (same type) should NOT be selected
-			expect(isSelected('rack-1', 1)).toBe(false);
+			// Device with uuid-2 (same type but different UUID) should NOT be selected
+			expect(isSelected('rack-1', 'uuid-2')).toBe(false);
 
 			// Device in different rack should NOT be selected
-			expect(isSelected('rack-2', 0)).toBe(false);
+			expect(isSelected('rack-2', 'uuid-1')).toBe(false);
+		});
+	});
+
+	describe('getSelectedDeviceIndex helper', () => {
+		it('converts device ID to array index', () => {
+			const store = getSelectionStore();
+			const devices: PlacedDevice[] = [
+				{ id: 'uuid-a', device_type: 'server', position: 1, face: 'front' },
+				{ id: 'uuid-b', device_type: 'server', position: 3, face: 'front' }
+			];
+
+			store.selectDevice('rack-1', 'uuid-b');
+
+			// Should return index 1 (the position of uuid-b in the array)
+			expect(store.getSelectedDeviceIndex(devices)).toBe(1);
+		});
+
+		it('returns null when device not found in array', () => {
+			const store = getSelectionStore();
+			const devices: PlacedDevice[] = [
+				{ id: 'uuid-a', device_type: 'server', position: 1, face: 'front' }
+			];
+
+			store.selectDevice('rack-1', 'uuid-not-in-array');
+
+			expect(store.getSelectedDeviceIndex(devices)).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Switch device selection from fragile index-based tracking to stable UUID-based tracking
- Selection now persists correctly when devices are added/removed/reordered
- Add `getSelectedDeviceIndex()` helper for components that still need array index

## Changes
- `selection.svelte.ts`: Replace `selectedDeviceIndex` with `selectedDeviceId`, add helper function
- Components updated: `Canvas`, `EditPanel`, `KeyboardHandler`, `Rack`, `RackDualView`, `App`
- Test files updated to use new `selectDevice(rackId, deviceId)` API

## Test plan
- [x] All 2374 tests pass
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual: Select device, add another device, verify original stays selected
- [ ] Manual: Select device, delete different device, verify selection persists

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)