### PR TITLE
fix: align LogoLockup logo with text baseline

### DIFF
--- a/src/lib/components/LogoLockup.svelte
+++ b/src/lib/components/LogoLockup.svelte
@@ -234,7 +234,7 @@
 <style>
 	.logo-lockup {
 		display: flex;
-		align-items: center;
+		align-items: flex-end;
 		gap: var(--space-2);
 	}
 


### PR DESCRIPTION
## Summary

- Changed flex alignment from `center` to `flex-end` so the logo icon bottom-aligns with the "Rackarr" text baseline

## Before/After

The logo icon was ~2-3px higher than the text. Now both elements share the same bottom edge.

## Test plan

- [x] Visual inspection in toolbar
- [x] Build passes
- [x] Tests pass

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)