### PR TITLE
fix(a11y): change canvas role from application to region (#145)

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -201,18 +201,50 @@
 	// NOTE: Rack reordering handlers removed in v0.1.1 (single-rack mode)
 	// NOTE: handleRackViewChange removed in v0.4 (dual-view mode - always show both)
 	// Restore in v0.3 when multi-rack support returns
+
+	// Screen reader accessible description of rack contents
+	const rackDescription = $derived.by(() => {
+		if (!rack) return 'No rack configured';
+		const deviceCount = rack.devices.length;
+		const deviceWord = deviceCount === 1 ? 'device' : 'devices';
+		return `${rack.name}, ${rack.height}U rack with ${deviceCount} ${deviceWord} placed`;
+	});
+
+	const deviceListDescription = $derived.by(() => {
+		if (!rack || rack.devices.length === 0) return '';
+		const deviceNames = rack.devices
+			.sort((a, b) => b.position - a.position) // Top to bottom
+			.map((d) => {
+				const deviceType = layoutStore.device_types.find((dt) => dt.slug === d.device_type);
+				const name = d.label || deviceType?.model || d.device_type;
+				return `U${d.position}: ${name}`;
+			});
+		return `Devices from top to bottom: ${deviceNames.join(', ')}`;
+	});
+
+	function handleCanvasKeydown(event: KeyboardEvent) {
+		// Handle Enter/Space as click for accessibility
+		if (event.key === 'Enter' || event.key === ' ') {
+			selectionStore.clearSelection();
+		}
+	}
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
 	class="canvas"
 	class:party-mode={partyMode}
-	role="application"
-	aria-label="Rack layout canvas"
+	role="region"
+	aria-label={rackDescription}
+	aria-describedby={deviceListDescription ? 'canvas-device-list' : undefined}
+	tabindex="0"
 	bind:this={canvasContainer}
 	onclick={handleCanvasClick}
+	onkeydown={handleCanvasKeydown}
 >
+	<!-- Hidden description for screen readers -->
+	{#if deviceListDescription}
+		<p id="canvas-device-list" class="sr-only">{deviceListDescription}</p>
+	{/if}
 	{#if hasRacks && rack}
 		<div class="panzoom-container" bind:this={panzoomContainer}>
 			<!-- Single-rack mode with dual-view: front and rear side-by-side (v0.4) -->

--- a/src/tests/AriaAudit.test.ts
+++ b/src/tests/AriaAudit.test.ts
@@ -139,19 +139,22 @@ describe('ARIA Labels Audit', () => {
 	});
 
 	describe('Canvas accessibility', () => {
-		it('canvas has role="application"', () => {
+		it('canvas has role="region" for proper screen reader navigation', () => {
 			const { container } = render(Canvas);
 
 			const canvas = container.querySelector('.canvas');
-			expect(canvas).toHaveAttribute('role', 'application');
+			// Changed from role="application" to role="region" in #145
+			// role="application" breaks standard screen reader navigation
+			expect(canvas).toHaveAttribute('role', 'region');
 		});
 
-		it('canvas has aria-label', () => {
+		it('canvas has dynamic aria-label describing rack state', () => {
 			const { container } = render(Canvas);
 
 			const canvas = container.querySelector('.canvas');
 			expect(canvas).toHaveAttribute('aria-label');
-			expect(canvas?.getAttribute('aria-label')).toBe('Rack layout canvas');
+			// Dynamic label includes rack name, height, and device count
+			expect(canvas?.getAttribute('aria-label')).toContain('rack');
 		});
 	});
 

--- a/src/tests/CanvasOverflow.test.ts
+++ b/src/tests/CanvasOverflow.test.ts
@@ -34,18 +34,22 @@ describe('Canvas Overflow Handling', () => {
 			expect(canvasElement).toHaveClass('canvas');
 		});
 
-		it('canvas has application role for accessibility', () => {
+		it('canvas has region role for accessibility (allows normal screen reader navigation)', () => {
 			const { container } = render(Canvas);
 
 			const canvasElement = container.querySelector('.canvas');
-			expect(canvasElement).toHaveAttribute('role', 'application');
+			expect(canvasElement).toHaveAttribute('role', 'region');
 		});
 
-		it('canvas has aria-label for accessibility', () => {
+		it('canvas has dynamic aria-label describing rack state', () => {
 			const { container } = render(Canvas);
 
 			const canvasElement = container.querySelector('.canvas');
-			expect(canvasElement).toHaveAttribute('aria-label', 'Rack layout canvas');
+			// Default layout has "Racky McRackface" 42U rack with 0 devices
+			expect(canvasElement).toHaveAttribute(
+				'aria-label',
+				'Racky McRackface, 42U rack with 0 devices placed'
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Change `role="application"` to `role="region"` for proper screen reader navigation
- Add dynamic `aria-label` describing rack state (name, height, device count)
- Add hidden device list description for screen readers (via `aria-describedby`)
- Add keyboard handler for Enter/Space to clear selection
- Add `tabindex="0"` for keyboard focusability

## Problem

The previous `role="application"` was blocking standard screen reader navigation keys. Screen reader users couldn't navigate the page normally - all keys were passed directly to the canvas.

## Solution

Changed to `role="region"` which creates a landmark that screen readers can navigate around normally. Added dynamic accessible descriptions so screen reader users know the rack state without needing to interact with the visual canvas.

## Test Plan

- [x] Lint passes
- [x] All tests pass (117 test files, 2434 tests)
- [x] Build succeeds
- [x] Updated existing a11y tests to verify new behavior

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)