### PR TITLE
fix: add background box to legend when using transparent export

### DIFF
--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -394,11 +394,7 @@ export function generateExportSVG(
 			: 0;
 	// Rack internal height: top padding + top rail + U slots + bottom rail + bottom padding
 	const rackAreaHeight =
-		maxRackHeight * U_HEIGHT +
-		RACK_PADDING +
-		RAIL_WIDTH * 2 +
-		RACK_BOTTOM_PADDING +
-		headerSpace;
+		maxRackHeight * U_HEIGHT + RACK_PADDING + RAIL_WIDTH * 2 + RACK_BOTTOM_PADDING + headerSpace;
 	const legendWidth = includeLegend ? 180 : 0;
 	const legendHeight = includeLegend
 		? usedDevices.length * LEGEND_ITEM_HEIGHT + LEGEND_PADDING * 2
@@ -605,8 +601,7 @@ export function generateExportSVG(
 
 				// Render blocked slot rectangles
 				for (const slot of blockedSlots) {
-					const slotY =
-						(rack.height - slot.top) * U_HEIGHT + RACK_PADDING + RAIL_WIDTH;
+					const slotY = (rack.height - slot.top) * U_HEIGHT + RACK_PADDING + RAIL_WIDTH;
 					const slotHeight = (slot.top - slot.bottom + 1) * U_HEIGHT;
 					const slotWidth = RACK_WIDTH - 2 * RAIL_WIDTH;
 
@@ -827,6 +822,24 @@ export function generateExportSVG(
 		const legendGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
 		legendGroup.setAttribute('class', 'export-legend');
 		legendGroup.setAttribute('transform', `translate(${legendX}, ${legendY})`);
+
+		// Add background box when using transparent background (so legend text is legible)
+		if (background === 'transparent') {
+			const legendBgPadding = 8;
+			const legendBgWidth = legendWidth + legendBgPadding * 2;
+			const legendBgHeight = legendHeight + legendBgPadding;
+
+			const legendBg = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+			legendBg.setAttribute('class', 'legend-background');
+			legendBg.setAttribute('x', String(-legendBgPadding));
+			legendBg.setAttribute('y', '0');
+			legendBg.setAttribute('width', String(legendBgWidth));
+			legendBg.setAttribute('height', String(legendBgHeight));
+			legendBg.setAttribute('fill', 'rgba(255, 255, 255, 0.95)');
+			legendBg.setAttribute('rx', '4');
+			legendBg.setAttribute('ry', '4');
+			legendGroup.appendChild(legendBg);
+		}
 
 		// Legend title
 		const legendTitle = document.createElementNS('http://www.w3.org/2000/svg', 'text');

--- a/src/tests/export.test.ts
+++ b/src/tests/export.test.ts
@@ -101,6 +101,39 @@ describe('Export Utilities', () => {
 			expect(legend).toBeNull();
 		});
 
+		it('legend has background box when transparent background is used', () => {
+			const options: ExportOptions = {
+				...defaultOptions,
+				includeLegend: true,
+				background: 'transparent'
+			};
+			const svg = generateExportSVG(mockRacks, mockDeviceLibrary, options);
+
+			const legend = svg.querySelector('.export-legend');
+			expect(legend).not.toBeNull();
+
+			// Legend should have a background rect for visibility on transparent backgrounds
+			const legendBg = legend?.querySelector('.legend-background');
+			expect(legendBg).not.toBeNull();
+			expect(legendBg?.getAttribute('fill')).toContain('rgba(255, 255, 255');
+		});
+
+		it('legend has no background box when non-transparent background is used', () => {
+			const options: ExportOptions = {
+				...defaultOptions,
+				includeLegend: true,
+				background: 'dark'
+			};
+			const svg = generateExportSVG(mockRacks, mockDeviceLibrary, options);
+
+			const legend = svg.querySelector('.export-legend');
+			expect(legend).not.toBeNull();
+
+			// Legend should NOT have a background rect when using dark/light background
+			const legendBg = legend?.querySelector('.legend-background');
+			expect(legendBg).toBeNull();
+		});
+
 		it('applies dark background', () => {
 			const options: ExportOptions = { ...defaultOptions, background: 'dark' };
 			const svg = generateExportSVG(mockRacks, mockDeviceLibrary, options);


### PR DESCRIPTION
## Summary

- Adds a white semi-transparent background box behind the legend when exporting with transparent background
- Legend text is now readable when the exported image is placed on colored/dark backgrounds

## Test plan

- [x] Legend has background box when `background: 'transparent'` and `includeLegend: true`
- [x] Legend has NO background box when using `dark` or `light` background
- [x] All export tests pass (77 tests)
- [ ] Manual test: Export with transparent + legend, verify text is legible on dark background

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)