### PR TITLE
refactor: slim starter library and expand brand packs

### DIFF
--- a/src/lib/data/brandPacks/apc.ts
+++ b/src/lib/data/brandPacks/apc.ts
@@ -107,5 +107,351 @@ export const apcDevices: DeviceType[] = [
 		is_full_depth: false,
 		colour: CATEGORY_COLOURS.power,
 		category: 'power'
+	},
+
+	// Additional devices from NetBox library
+	{
+		slug: 'apc-ap4421',
+		u_height: 1,
+		manufacturer: 'APC',
+		model: 'AP4421',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-ap4421a',
+		u_height: 1,
+		manufacturer: 'APC',
+		model: 'AP4421A',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-ap4422a',
+		u_height: 1,
+		manufacturer: 'APC',
+		model: 'AP4422A',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-ap4423',
+		u_height: 1,
+		manufacturer: 'APC',
+		model: 'AP4423',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-ap4423a',
+		u_height: 1,
+		manufacturer: 'APC',
+		model: 'AP4423A',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-srt72rmbp',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'APC Smart-UPS SRT, 72 V, 2,2 kVA, Rackmount Battery Module',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt1500rm2u',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SMT1500RM2U',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smart-ups-srt-2200va-rm',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT 2200VA RM',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smart-ups-srt-2200va-rm-nc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT 2200VA RM NC',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smart-ups-srt-5000va-200v',
+		u_height: 3,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT 5000VA 200V',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smart-ups-srt-5000va-rm-208-230v-hw',
+		u_height: 3,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT 5000VA RM 208/230V HW',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smart-ups-srt-5000va-rm-208v-iec',
+		u_height: 3,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT 5000VA RM 208V IEC',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smart-ups-srt-5000va-rm-230v',
+		u_height: 3,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT 5000VA RM 230V',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smart-ups-srt-6000va-rm-230v',
+		u_height: 4,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT 6000VA RM 230V',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smart-ups-srt-8000va-rm-208v',
+		u_height: 6,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT 8000VA RM 208V',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-srt1000uxi-ncli',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT1000UXI-NCLI',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-srt1500rmxli-nc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT1500RMXLI-NC',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-srt1500uxi-ncli',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT1500UXI-NCLI',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-srt3000rmxlt',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT3000RMXLT',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-srt3000uxi-ncli',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT3000UXI-NCLI',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-srt5krmxlt',
+		u_height: 3,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRT5KRMXLT',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-srtg6kxli-ncli',
+		u_height: 4,
+		manufacturer: 'APC',
+		model: 'Smart-UPS SRTG6KXLI-NCLI',
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt1000rmi2uc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMT1000RMI2UC',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt1500rmi1u',
+		u_height: 1,
+		manufacturer: 'APC',
+		model: 'SMT1500RMI1U',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt1500rmi2u',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMT1500RMI2U',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt1500rmi2uc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMT1500RMI2UC',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt1500rmi2unc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMT1500RMI2UNC',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt2200rm2unc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMT2200RM2UNC',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt2200rmi2unc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMT2200RMI2UNC',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt3000rmi2u',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMT3000RMI2U',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt3000rmi2uc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMT3000RMI2UC',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smt3000rmi2unc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMT3000RMI2UNC',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smx120bp',
+		u_height: 4,
+		manufacturer: 'APC',
+		model: 'SMX120BP',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smx1500rm2unc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMX1500RM2UNC',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smx1500rmi2u',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMX1500RMI2U',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smx2200hv',
+		u_height: 4,
+		manufacturer: 'APC',
+		model: 'SMX2200HV',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smx3000hvnc',
+		u_height: 4,
+		manufacturer: 'APC',
+		model: 'SMX3000HVNC',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smx3000rmhv2unc',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMX3000RMHV2UNC',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smx3000rmlv2u',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMX3000RMLV2U',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'apc-smx48rmbp2u',
+		u_height: 2,
+		manufacturer: 'APC',
+		model: 'SMX48RMBP2U',
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
 	}
 ];

--- a/src/lib/data/brandPacks/blackmagicdesign.ts
+++ b/src/lib/data/brandPacks/blackmagicdesign.ts
@@ -1,0 +1,84 @@
+/**
+ * Blackmagicdesign Brand Pack
+ * Pre-defined device types for Blackmagicdesign rack-mountable devices
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+/**
+ * Blackmagicdesign device definitions (7 devices)
+ */
+export const blackmagicdesignDevices: DeviceType[] = [
+	{
+		slug: 'blackmagicdesign-atem-constellation-1-m-e-4k',
+		u_height: 1,
+		manufacturer: 'Blackmagicdesign',
+		model: 'ATEM Constellation 1 M/E 4k',
+		is_full_depth: false,
+		airflow: 'right-to-left',
+		colour: CATEGORY_COLOURS.avmedia,
+		category: 'av-media'
+	},
+	{
+		slug: 'blackmagicdesign-atem-constellation-1-m-e-hd',
+		u_height: 1,
+		manufacturer: 'Blackmagicdesign',
+		model: 'ATEM Constellation 1 M/E HD',
+		is_full_depth: false,
+		airflow: 'right-to-left',
+		colour: CATEGORY_COLOURS.avmedia,
+		category: 'av-media'
+	},
+	{
+		slug: 'blackmagicdesign-atem-constellation-2-m-e-4k',
+		u_height: 1,
+		manufacturer: 'Blackmagicdesign',
+		model: 'ATEM Constellation 2 M/E 4k',
+		is_full_depth: false,
+		airflow: 'right-to-left',
+		colour: CATEGORY_COLOURS.avmedia,
+		category: 'av-media'
+	},
+	{
+		slug: 'blackmagicdesign-atem-constellation-2-m-e-hd',
+		u_height: 1,
+		manufacturer: 'Blackmagicdesign',
+		model: 'ATEM Constellation 2 M/E HD',
+		is_full_depth: false,
+		airflow: 'right-to-left',
+		colour: CATEGORY_COLOURS.avmedia,
+		category: 'av-media'
+	},
+	{
+		slug: 'blackmagicdesign-atem-constellation-4-m-e-4k',
+		u_height: 2,
+		manufacturer: 'Blackmagicdesign',
+		model: 'ATEM Constellation 4 M/E 4k',
+		is_full_depth: false,
+		airflow: 'right-to-left',
+		colour: CATEGORY_COLOURS.avmedia,
+		category: 'av-media'
+	},
+	{
+		slug: 'blackmagicdesign-atem-constellation-4-m-e-hd',
+		u_height: 2,
+		manufacturer: 'Blackmagicdesign',
+		model: 'ATEM Constellation 4 M/E HD',
+		is_full_depth: false,
+		airflow: 'right-to-left',
+		colour: CATEGORY_COLOURS.avmedia,
+		category: 'av-media'
+	},
+	{
+		slug: 'blackmagicdesign-atem-constellation-8k',
+		u_height: 2,
+		manufacturer: 'Blackmagicdesign',
+		model: 'ATEM Constellation 8K',
+		is_full_depth: false,
+		airflow: 'right-to-left',
+		colour: CATEGORY_COLOURS.avmedia,
+		category: 'av-media'
+	}
+];

--- a/src/lib/data/brandPacks/cyberpower.ts
+++ b/src/lib/data/brandPacks/cyberpower.ts
@@ -1,0 +1,105 @@
+/**
+ * CyberPower Brand Pack
+ * Pre-defined device types for CyberPower rack-mountable devices
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+/**
+ * CyberPower device definitions (10 devices)
+ */
+export const cyberpowerDevices: DeviceType[] = [
+	{
+		slug: 'cyberpower-cps-1220rms',
+		u_height: 1,
+		manufacturer: 'CyberPower',
+		model: 'CPS-1220RMS',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'cyberpower-cps1215rm',
+		u_height: 1,
+		manufacturer: 'CyberPower',
+		model: 'CPS1215RM',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'cyberpower-cps1215rms',
+		u_height: 1,
+		manufacturer: 'CyberPower',
+		model: 'CPS1215RMS',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'cyberpower-or1000lcdrm1u',
+		u_height: 1,
+		manufacturer: 'CyberPower',
+		model: 'OR1000LCDRM1U',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'cyberpower-or1500lcdrtxl2u',
+		u_height: 2,
+		manufacturer: 'CyberPower',
+		model: 'OR1500LCDRTXL2U',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'cyberpower-or2200lcdrt2u',
+		u_height: 2,
+		manufacturer: 'CyberPower',
+		model: 'OR2200LCDRT2U',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'cyberpower-or600elcdrm1u',
+		u_height: 1,
+		manufacturer: 'CyberPower',
+		model: 'OR600ELCDRM1U',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'cyberpower-pdu15m2f12r',
+		u_height: 1,
+		manufacturer: 'CyberPower',
+		model: 'PDU15M2F12R',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'cyberpower-pdu20bhviec12r',
+		u_height: 1,
+		manufacturer: 'CyberPower',
+		model: 'PDU20BHVIEC12R',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'cyberpower-pdu81005',
+		u_height: 1,
+		manufacturer: 'CyberPower',
+		model: 'PDU81005',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	}
+];

--- a/src/lib/data/brandPacks/dell.ts
+++ b/src/lib/data/brandPacks/dell.ts
@@ -258,5 +258,376 @@ export const dellDevices: DeviceType[] = [
 		is_full_depth: true,
 		colour: CATEGORY_COLOURS.server,
 		category: 'server'
+	},
+
+	// Additional devices from NetBox library
+	{
+		slug: 'dell-poweredge-1950',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge 1950',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-c6400',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge C6400',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-m1000e',
+		u_height: 10,
+		manufacturer: 'Dell',
+		model: 'PowerEdge M1000e',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-mx7000',
+		u_height: 7,
+		manufacturer: 'Dell',
+		model: 'PowerEdge MX7000',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r320',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R320',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r330',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R330',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r340',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R340',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r350',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R350',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r360',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R360',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r420',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R420',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r540',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R540',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r610',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R610',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r620',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R620',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r630',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R630',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r640',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R640',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r650',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R650',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r650xs',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R650xs',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r6515',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R6515',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r6525',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R6525',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r660',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R660',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r660xs',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R660xs',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r6615',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R6615',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r6625',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R6625',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r6715',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R6715',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r6725',
+		u_height: 1,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R6725',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r720',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R720',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r720xd',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R720xd',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r730',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R730',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r730xd',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R730xd',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r740',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R740',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r740xd',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R740xd',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r740xd2',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R740xd2',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r750xs',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R750xs',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r7515',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R7515',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r7525',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R7525',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r7615',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R7615',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r7625',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R7625',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r7715',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R7715',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r7725',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R7725',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r815',
+		u_height: 2,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R815',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-r940',
+		u_height: 3,
+		manufacturer: 'Dell',
+		model: 'PowerEdge R940',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-t630',
+		u_height: 5,
+		manufacturer: 'Dell',
+		model: 'PowerEdge T630',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'dell-poweredge-t640',
+		u_height: 5,
+		manufacturer: 'Dell',
+		model: 'PowerEdge T640',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
 	}
 ];

--- a/src/lib/data/brandPacks/eaton.ts
+++ b/src/lib/data/brandPacks/eaton.ts
@@ -1,0 +1,190 @@
+/**
+ * Eaton Brand Pack
+ * Pre-defined device types for Eaton rack-mountable devices
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+/**
+ * Eaton device definitions (20 devices)
+ */
+export const eatonDevices: DeviceType[] = [
+	{
+		slug: 'eaton-5px1500irt',
+		u_height: 2,
+		manufacturer: 'Eaton',
+		model: '5PX1500iRT',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-5px2200irt',
+		u_height: 2,
+		manufacturer: 'Eaton',
+		model: '5PX2200IRT',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-5px3000irt2u',
+		u_height: 2,
+		manufacturer: 'Eaton',
+		model: '5PX3000IRT2U',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-5px3000rtn',
+		u_height: 2,
+		manufacturer: 'Eaton',
+		model: '5PX3000RTN',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-5sx1750rau',
+		u_height: 2,
+		manufacturer: 'Eaton',
+		model: '5SX1750RAU',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-9px-1000i-rt-2u',
+		u_height: 2,
+		manufacturer: 'Eaton',
+		model: '9PX 1000i RT 2U',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-9px-3000i-rt-2u',
+		u_height: 2,
+		manufacturer: 'Eaton',
+		model: '9PX 3000i RT 2U',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-9px3000irt3u',
+		u_height: 3,
+		manufacturer: 'Eaton',
+		model: '9PX3000iRT3U',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-9px5kirtn',
+		u_height: 3,
+		manufacturer: 'Eaton',
+		model: '9PX5KIRTN',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-9px6k',
+		u_height: 3,
+		manufacturer: 'Eaton',
+		model: '9PX6K',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-9pxebm180',
+		u_height: 3,
+		manufacturer: 'Eaton',
+		model: '9PXEBM180',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-9pxebm72rt2u',
+		u_height: 2,
+		manufacturer: 'Eaton',
+		model: '9PXEBM72RT2U',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-emat08-10',
+		u_height: 1,
+		manufacturer: 'Eaton',
+		model: 'EMAT08-10',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-pdumh30hvnet',
+		u_height: 2,
+		manufacturer: 'Eaton',
+		model: 'PDUMH30HVNET',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-pw103ba1u405',
+		u_height: 1,
+		manufacturer: 'Eaton',
+		model: 'PW103BA1U405',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-tripp-lite-b040-008-19',
+		u_height: 1,
+		manufacturer: 'Eaton',
+		model: 'Tripp Lite B040-008-19',
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-tripp-lite-b064-016-02-ipg',
+		u_height: 1,
+		manufacturer: 'Eaton',
+		model: 'Tripp Lite B064-016-02-IPG',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-tripp-lite-b064-032-01-ipg',
+		u_height: 1,
+		manufacturer: 'Eaton',
+		model: 'Tripp Lite B064-032-01-IPG',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-tripp-lite-b072-032-ip2',
+		u_height: 1,
+		manufacturer: 'Eaton',
+		model: 'Tripp Lite B072-032-IP2',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	},
+	{
+		slug: 'eaton-tripp-lite-b096-016',
+		u_height: 1,
+		manufacturer: 'Eaton',
+		model: 'Tripp Lite B096-016',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.power,
+		category: 'power'
+	}
+];

--- a/src/lib/data/brandPacks/fortinet.ts
+++ b/src/lib/data/brandPacks/fortinet.ts
@@ -1,0 +1,201 @@
+/**
+ * Fortinet Brand Pack
+ * Pre-defined device types for Fortinet rack-mountable devices
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+/**
+ * Fortinet device definitions (20 devices)
+ */
+export const fortinetDevices: DeviceType[] = [
+	{
+		slug: 'fortinet-fg-1000d',
+		u_height: 2,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 1000D',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-100d',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 100D',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-100e',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 100E',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-100ef',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 100EF',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-100f',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 100F',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-1100e',
+		u_height: 2,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 1100E',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-1200d',
+		u_height: 2,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 1200D',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-1800f',
+		u_height: 2,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 1800F',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-1801f',
+		u_height: 2,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 1801F',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-200d',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 200D',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-200e',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 200E',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-200f',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 200F',
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-200g',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 200G',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-2200e',
+		u_height: 2,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 2200E',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-2600f',
+		u_height: 2,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 2600F',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-3200d',
+		u_height: 2,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 3200D',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-600e',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 600E',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-600f',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 600F',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-601e',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate 601E',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'fortinet-fg-600d',
+		u_height: 1,
+		manufacturer: 'Fortinet',
+		model: 'FortiGate-600D',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	}
+];

--- a/src/lib/data/brandPacks/hpe.ts
+++ b/src/lib/data/brandPacks/hpe.ts
@@ -187,5 +187,291 @@ export const hpeDevices: DeviceType[] = [
 		category: 'network',
 		front_image: true,
 		rear_image: true
+	},
+
+	// Additional devices from NetBox library
+	{
+		slug: 'hpe-proliant-dl180-gen6',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL180 Gen6',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl20-gen10',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL20 Gen10',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl325-gen10',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL325 Gen10',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl325-gen10-plus',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL325 Gen10 Plus',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl325-gen10-plus-v2',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL325 Gen10 Plus v2',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl325-gen11',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL325 Gen11',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl345-gen11',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL345 Gen11',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl360-gen10-plus',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL360 Gen10 Plus',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl360-gen7',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL360 Gen7',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl360e-gen8',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL360e Gen8',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl360p-gen8',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL360p Gen8',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl365-gen11',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL365 Gen11',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl380-gen10-plus',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL380 Gen10 Plus',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl380-gen5',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL380 Gen5',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl380e-gen8',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL380e Gen8',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl385-gen10-plus-v2',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL385 Gen10 Plus v2',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl385-gen11',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL385 Gen11',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl385p-gen8',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL385p Gen8',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl560-gen10',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL560 Gen10',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl580-gen10',
+		u_height: 4,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL580 Gen10',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl580-gen9',
+		u_height: 4,
+		manufacturer: 'HPE',
+		model: 'ProLiant DL580 Gen9',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dx360-gen10',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant DX360 Gen10',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dx385-gen10-plus',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DX385 Gen10 Plus',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dx385-gen10-plus-v2',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant DX385 Gen10 Plus V2',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-ml110-gen10',
+		u_height: 3,
+		manufacturer: 'HPE',
+		model: 'ProLiant ML110 Gen10',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-ml110-gen9',
+		u_height: 3,
+		manufacturer: 'HPE',
+		model: 'ProLiant ML110 Gen9',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-ml30-gen10-plus',
+		u_height: 4,
+		manufacturer: 'HPE',
+		model: 'ProLiant ML30 Gen10 Plus',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-ml350-gen10',
+		u_height: 4,
+		manufacturer: 'HPE',
+		model: 'ProLiant ML350 Gen10',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-ml350-gen9',
+		u_height: 4,
+		manufacturer: 'HPE',
+		model: 'ProLiant ML350 Gen9',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-ml350p-gen8',
+		u_height: 4,
+		manufacturer: 'HPE',
+		model: 'ProLiant ML350p Gen8',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-xl420-gen9',
+		u_height: 2,
+		manufacturer: 'HPE',
+		model: 'ProLiant XL420 Gen9',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl120-gen7',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant-DL120-Gen7',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'hpe-proliant-dl320-gen6',
+		u_height: 1,
+		manufacturer: 'HPE',
+		model: 'ProLiant-DL320-Gen6',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
 	}
 ];

--- a/src/lib/data/brandPacks/index.ts
+++ b/src/lib/data/brandPacks/index.ts
@@ -12,6 +12,16 @@ import { apcDevices } from './apc';
 import { dellDevices } from './dell';
 import { supermicroDevices } from './supermicro';
 import { hpeDevices } from './hpe';
+// New brand packs
+import { fortinetDevices } from './fortinet';
+import { eatonDevices } from './eaton';
+import { netgearDevices } from './netgear';
+import { paloaltoDevices } from './palo-alto';
+import { qnapDevices } from './qnap';
+import { lenovoDevices } from './lenovo';
+import { cyberpowerDevices } from './cyberpower';
+import { netgateDevices } from './netgate';
+import { blackmagicdesignDevices } from './blackmagicdesign';
 
 export {
 	ubiquitiDevices,
@@ -21,7 +31,17 @@ export {
 	apcDevices,
 	dellDevices,
 	supermicroDevices,
-	hpeDevices
+	hpeDevices,
+	// New brand packs
+	fortinetDevices,
+	eatonDevices,
+	netgearDevices,
+	paloaltoDevices,
+	qnapDevices,
+	lenovoDevices,
+	cyberpowerDevices,
+	netgateDevices,
+	blackmagicdesignDevices
 };
 
 /**
@@ -64,6 +84,33 @@ export function getBrandPacks(): BrandSection[] {
 			defaultExpanded: false,
 			icon: 'tplink'
 		},
+		{
+			id: 'fortinet',
+			title: 'Fortinet',
+			devices: fortinetDevices,
+			defaultExpanded: false,
+			icon: 'fortinet'
+		},
+		{
+			id: 'netgear',
+			title: 'Netgear',
+			devices: netgearDevices,
+			defaultExpanded: false,
+			icon: 'netgear'
+		},
+		{
+			id: 'palo-alto',
+			title: 'Palo Alto',
+			devices: paloaltoDevices,
+			defaultExpanded: false,
+			icon: 'paloaltonetworks'
+		},
+		{
+			id: 'netgate',
+			title: 'Netgate',
+			devices: netgateDevices,
+			defaultExpanded: false
+		},
 		// Storage
 		{
 			id: 'synology',
@@ -72,13 +119,33 @@ export function getBrandPacks(): BrandSection[] {
 			defaultExpanded: false,
 			icon: 'synology'
 		},
-		// Power (APC is owned by Schneider Electric)
+		{
+			id: 'qnap',
+			title: 'QNAP',
+			devices: qnapDevices,
+			defaultExpanded: false,
+			icon: 'qnap'
+		},
+		// Power
 		{
 			id: 'apc',
 			title: 'APC',
 			devices: apcDevices,
 			defaultExpanded: false,
 			icon: 'schneiderelectric'
+		},
+		{
+			id: 'eaton',
+			title: 'Eaton',
+			devices: eatonDevices,
+			defaultExpanded: false,
+			icon: 'eaton'
+		},
+		{
+			id: 'cyberpower',
+			title: 'CyberPower',
+			devices: cyberpowerDevices,
+			defaultExpanded: false
 		},
 		// Servers
 		{
@@ -101,6 +168,21 @@ export function getBrandPacks(): BrandSection[] {
 			devices: hpeDevices,
 			defaultExpanded: false,
 			icon: 'hp'
+		},
+		{
+			id: 'lenovo',
+			title: 'Lenovo',
+			devices: lenovoDevices,
+			defaultExpanded: false,
+			icon: 'lenovo'
+		},
+		// AV/Media
+		{
+			id: 'blackmagicdesign',
+			title: 'Blackmagic Design',
+			devices: blackmagicdesignDevices,
+			defaultExpanded: false,
+			icon: 'blackmagicdesign'
 		}
 	];
 }
@@ -126,6 +208,24 @@ export function getBrandDevices(brandId: string): DeviceType[] {
 			return supermicroDevices;
 		case 'hpe':
 			return hpeDevices;
+		case 'fortinet':
+			return fortinetDevices;
+		case 'eaton':
+			return eatonDevices;
+		case 'netgear':
+			return netgearDevices;
+		case 'palo-alto':
+			return paloaltoDevices;
+		case 'qnap':
+			return qnapDevices;
+		case 'lenovo':
+			return lenovoDevices;
+		case 'cyberpower':
+			return cyberpowerDevices;
+		case 'netgate':
+			return netgateDevices;
+		case 'blackmagicdesign':
+			return blackmagicdesignDevices;
 		default:
 			return [];
 	}
@@ -145,7 +245,16 @@ export function findBrandDevice(slug: string): DeviceType | undefined {
 		...apcDevices,
 		...dellDevices,
 		...supermicroDevices,
-		...hpeDevices
+		...hpeDevices,
+		...fortinetDevices,
+		...eatonDevices,
+		...netgearDevices,
+		...paloaltoDevices,
+		...qnapDevices,
+		...lenovoDevices,
+		...cyberpowerDevices,
+		...netgateDevices,
+		...blackmagicdesignDevices
 	];
 
 	return allDevices.find((d) => d.slug === slug);
@@ -168,7 +277,16 @@ export function getBrandSlugs(): Set<string> {
 			...apcDevices,
 			...dellDevices,
 			...supermicroDevices,
-			...hpeDevices
+			...hpeDevices,
+			...fortinetDevices,
+			...eatonDevices,
+			...netgearDevices,
+			...paloaltoDevices,
+			...qnapDevices,
+			...lenovoDevices,
+			...cyberpowerDevices,
+			...netgateDevices,
+			...blackmagicdesignDevices
 		];
 		brandSlugsCache = new Set(allDevices.map((d) => d.slug));
 	}

--- a/src/lib/data/brandPacks/lenovo.ts
+++ b/src/lib/data/brandPacks/lenovo.ts
@@ -1,0 +1,100 @@
+/**
+ * Lenovo Brand Pack
+ * Pre-defined device types for Lenovo rack-mountable devices
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+/**
+ * Lenovo device definitions (10 devices)
+ */
+export const lenovoDevices: DeviceType[] = [
+	{
+		slug: 'lenovo-thinksystem-sr250-v2',
+		u_height: 1,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR250 V2',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'lenovo-thinksystem-sr530',
+		u_height: 1,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR530',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'lenovo-thinksystem-sr550',
+		u_height: 2,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR550',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'lenovo-thinksystem-sr630',
+		u_height: 1,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR630',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'lenovo-thinksystem-sr635',
+		u_height: 1,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR635',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'lenovo-thinksystem-sr645',
+		u_height: 1,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR645',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'lenovo-thinksystem-sr650',
+		u_height: 2,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR650',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'lenovo-thinksystem-sr650-v2',
+		u_height: 2,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR650 V2',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'lenovo-thinksystem-sr655-v3',
+		u_height: 2,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR655 V3',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'lenovo-thinksystem-sr665-v3',
+		u_height: 2,
+		manufacturer: 'Lenovo',
+		model: 'ThinkSystem SR665 V3',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	}
+];

--- a/src/lib/data/brandPacks/mikrotik.ts
+++ b/src/lib/data/brandPacks/mikrotik.ts
@@ -288,5 +288,288 @@ export const mikrotikDevices: DeviceType[] = [
 		is_full_depth: false,
 		colour: CATEGORY_COLOURS.network,
 		category: 'network'
+	},
+
+	// Additional devices from NetBox library
+	{
+		slug: 'mikrotik-ccr1009-7g-1c-1s-plus',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1009-7G-1C-1S+',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1009-7g-1c-1s-plus-pc',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1009-7G-1C-1S+PC',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1009-7g-1c-pc',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1009-7G-1C-PC',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1009-8g-1s-1s-plus',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1009-8G-1S-1S+',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1016-12g',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1016-12G',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1016-12s-1s-plus',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1016-12S-1S+',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1016-12s-1s-plus-r2',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1016-12S-1S+-r2',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1036-12g-4s',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1036-12G-4S',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1036-12g-4s-em',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1036-12G-4S-EM',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1036-8g-2s-plus',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1036-8G-2S+',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1036-8g-2s-plus-em',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1036-8G-2S+EM',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr1072-1g-8s-plus',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR1072-1G-8S+',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr2004-16g-2s-plus',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR2004-16G-2S+',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr2004-1g-12s-plus-2xs',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR2004-1G-12S+2XS',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr2116-12g-4s-plus',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR2116-12G-4S+',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-ccr2216-1g-12xs-2xq',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CCR2216-1G-12XS-2XQ',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs305-1g-4s-plus-in',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS305-1G-4S+IN',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs309-1g-8s-plus-in',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS309-1G-8S+IN',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs310-1g-5s-4s-plus-in',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS310-1G-5S-4S+IN',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs310-8g-plus-2s-plus-in',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS310-8G+2S+IN',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs312-4c-plus-8xg-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS312-4C+8XG-RM',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs317-1g-16s-plus-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS317-1G-16S+RM',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs320-8p-8b-4s-plus-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS320-8P-8B-4S+RM',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs326-24g-2s-plus-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS326-24G-2S+RM',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs326-24s-plus-2q-plus-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS326-24S+2Q+RM',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs326-4c-plus-20g-plus-2q-plus-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS326-4C+20G+2Q+RM',
+		is_full_depth: false,
+		airflow: 'mixed',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs328-24p-4s-plus-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS328-24P-4S+RM',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs328-4c-20s-4s-plus-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS328-4C-20S-4S+RM',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs354-48g-4s-plus-2q-plus-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS354-48G-4S+2Q+RM',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'mikrotik-crs354-48p-4s-plus-2q-plus-rm',
+		u_height: 1,
+		manufacturer: 'MikroTik',
+		model: 'CRS354-48P-4S+2Q+RM',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
 	}
 ];

--- a/src/lib/data/brandPacks/netgate.ts
+++ b/src/lib/data/brandPacks/netgate.ts
@@ -1,0 +1,93 @@
+/**
+ * Netgate Brand Pack
+ * Pre-defined device types for Netgate rack-mountable devices
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+/**
+ * Netgate device definitions (8 devices)
+ */
+export const netgateDevices: DeviceType[] = [
+	{
+		slug: 'netgate-1100-security-gateway',
+		u_height: 1,
+		manufacturer: 'Netgate',
+		model: '1100 Security Gateway',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgate-1537-security-gateway',
+		u_height: 1,
+		manufacturer: 'Netgate',
+		model: '1537 Security Gateway',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgate-3100-security-gateway',
+		u_height: 1,
+		manufacturer: 'Netgate',
+		model: '3100 Security Gateway',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgate-4100-security-gateway',
+		u_height: 1,
+		manufacturer: 'Netgate',
+		model: '4100 Security Gateway',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgate-6100-security-gateway',
+		u_height: 1,
+		manufacturer: 'Netgate',
+		model: '6100 Security Gateway',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgate-7100-security-gateway',
+		u_height: 1,
+		manufacturer: 'Netgate',
+		model: '7100 Security Gateway',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgate-8200-max-pfsense-plus-security-gateway',
+		u_height: 1,
+		manufacturer: 'Netgate',
+		model: '8200 Max PFSense+ Security Gateway',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgate-8300-security-gateway',
+		u_height: 1,
+		manufacturer: 'Netgate',
+		model: '8300 Security Gateway',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	}
+];

--- a/src/lib/data/brandPacks/netgear.ts
+++ b/src/lib/data/brandPacks/netgear.ts
@@ -1,0 +1,183 @@
+/**
+ * Netgear Brand Pack
+ * Pre-defined device types for Netgear rack-mountable devices
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+/**
+ * Netgear device definitions (18 devices)
+ */
+export const netgearDevices: DeviceType[] = [
+	{
+		slug: 'netgear-gs105',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS105',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs105e',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS105E',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs108',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS108',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs108e',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS108E',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs108lp',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS108LP',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs108pp',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS108PP',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs110emx',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS110EMX',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs116',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS116',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs116ev2',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS116Ev2',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs324tp',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS324TP',
+		is_full_depth: false,
+		airflow: 'left-to-right',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-gs724t',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'GS724T',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-prosafe-gsm7328fs',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'ProSafe GSM7328FS',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-prosafe-gsm7228s',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'ProSafe M5300-28G (GSM7228S)',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-prosafe-gsm7228ps',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'ProSafe M5300-28G-POE+ (GSM7228PS)',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-prosafe-gsm7252s',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'ProSafe M5300-52G (GSM7252S)',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-prosafe-gsm7252ps',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'ProSafe M5300-52G-POE+ (GSM7252PS)',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-s3300-28x-poep',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'S3300-28X-PoE+',
+		is_full_depth: false,
+		airflow: 'right-to-left',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'netgear-s3300-52x',
+		u_height: 1,
+		manufacturer: 'Netgear',
+		model: 'S3300-52X',
+		is_full_depth: false,
+		airflow: 'right-to-left',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	}
+];

--- a/src/lib/data/brandPacks/palo-alto.ts
+++ b/src/lib/data/brandPacks/palo-alto.ts
@@ -1,0 +1,153 @@
+/**
+ * Palo Alto Brand Pack
+ * Pre-defined device types for Palo Alto rack-mountable devices
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+/**
+ * Palo Alto device definitions (15 devices)
+ */
+export const paloaltoDevices: DeviceType[] = [
+	{
+		slug: 'palo-alto-pa-1410',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-1410',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-1420',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-1420',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-200',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-200',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-220-rack-kit',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-220 Rack Kit',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-220-rack-tray-kit',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-220 Rack Tray Kit',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3020',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3020',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3050',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3050',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3060',
+		u_height: 2,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3060',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3220',
+		u_height: 2,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3220',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3250',
+		u_height: 2,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3250',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3260',
+		u_height: 2,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3260',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3410',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3410',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3420',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3420',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3430',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3430',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'palo-alto-pa-3440',
+		u_height: 1,
+		manufacturer: 'Palo Alto',
+		model: 'PA-3440',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	}
+];

--- a/src/lib/data/brandPacks/qnap.ts
+++ b/src/lib/data/brandPacks/qnap.ts
@@ -1,0 +1,131 @@
+/**
+ * QNAP Brand Pack
+ * Pre-defined device types for QNAP rack-mountable devices
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+/**
+ * QNAP device definitions (13 devices)
+ */
+export const qnapDevices: DeviceType[] = [
+	{
+		slug: 'qnap-ts-1263u-rp',
+		u_height: 2,
+		manufacturer: 'QNAP',
+		model: 'TS-1263U-RP',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-1683xu-rp',
+		u_height: 3,
+		manufacturer: 'QNAP',
+		model: 'TS-1683XU-RP',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-431u',
+		u_height: 1,
+		manufacturer: 'QNAP',
+		model: 'TS-431U',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-432pxu',
+		u_height: 1,
+		manufacturer: 'QNAP',
+		model: 'TS-432PXU',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-432pxu-rp',
+		u_height: 1,
+		manufacturer: 'QNAP',
+		model: 'TS-432PXU-RP',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-463u-rp',
+		u_height: 1,
+		manufacturer: 'QNAP',
+		model: 'TS-463U-RP',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-832pxu-rp',
+		u_height: 2,
+		manufacturer: 'QNAP',
+		model: 'TS-832PXU-RP',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-873aeu',
+		u_height: 2,
+		manufacturer: 'QNAP',
+		model: 'TS-873AeU',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-879u-rp',
+		u_height: 2,
+		manufacturer: 'QNAP',
+		model: 'TS-879U-RP',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-883xu-rp',
+		u_height: 2,
+		manufacturer: 'QNAP',
+		model: 'TS-883XU-RP',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-ec1280u',
+		u_height: 2,
+		manufacturer: 'QNAP',
+		model: 'TS-EC1280U',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-ts-h1886xu-rp',
+		u_height: 2,
+		manufacturer: 'QNAP',
+		model: 'TS-h1886XU-RP',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'qnap-tvs-ec1580mu-sas-rp',
+		u_height: 2,
+		manufacturer: 'QNAP',
+		model: 'TVS-EC1580MU-SAS-RP',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	}
+];

--- a/src/lib/data/brandPacks/supermicro.ts
+++ b/src/lib/data/brandPacks/supermicro.ts
@@ -92,5 +92,141 @@ export const supermicroDevices: DeviceType[] = [
 		is_full_depth: true,
 		colour: CATEGORY_COLOURS.storage,
 		category: 'storage'
+	},
+
+	// Additional devices from NetBox library
+	{
+		slug: 'supermicro-as-2124bt-hntr',
+		u_height: 2,
+		manufacturer: 'Supermicro',
+		model: 'A+ Server 2124BT-HNTR',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-asg-2015s-e1cr24l',
+		u_height: 2,
+		manufacturer: 'Supermicro',
+		model: 'ASG-2015S-E1CR24L',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-as-3015mr-h8tnr',
+		u_height: 3,
+		manufacturer: 'Supermicro',
+		model: 'MicroCloud A+ Server AS 3015MR-H8TNR',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-sse-g3648b',
+		u_height: 1,
+		manufacturer: 'Supermicro',
+		model: 'SSE-G3648B',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-ssg-610p-acr12n4h',
+		u_height: 1,
+		manufacturer: 'Supermicro',
+		model: 'Storage SuperServer SSG-610P-ACR12N4H',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-storage-superserver-ssg-620p-e1cr24l',
+		u_height: 2,
+		manufacturer: 'Supermicro',
+		model: 'Storage SuperServer SSG-620P-E1CR24L',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-ssg-640p-e1cr36l',
+		u_height: 4,
+		manufacturer: 'Supermicro',
+		model: 'Storage SuperServer SSG-640P-E1CR36L',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-sse-x3348tr',
+		u_height: 1,
+		manufacturer: 'Supermicro',
+		model: 'Supermicro SSE-X3348TR',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-sys-1029u-tr4t',
+		u_height: 1,
+		manufacturer: 'Supermicro',
+		model: 'SuperServer 1029U-TR4T',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-as-1014s-wtrt',
+		u_height: 1,
+		manufacturer: 'Supermicro',
+		model: 'SuperServer A+ Server 1014S-WTRT',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-sys-110p-wtr',
+		u_height: 1,
+		manufacturer: 'Supermicro',
+		model: 'SuperServer SYS-110P-WTR',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-superstorage-6027r-e1r12n',
+		u_height: 2,
+		manufacturer: 'Supermicro',
+		model: 'SuperStorage 6027R-E1R12N',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-superstorage-6038r-e1cr16h',
+		u_height: 3,
+		manufacturer: 'Supermicro',
+		model: 'SuperStorage 6038r-E1CR16H',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-sys-1019p-wtr',
+		u_height: 1,
+		manufacturer: 'Supermicro',
+		model: 'SYS-1019P-WTR',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
+	},
+	{
+		slug: 'supermicro-sys-1028r-wc1rt',
+		u_height: 1,
+		manufacturer: 'Supermicro',
+		model: 'SYS-1028R-WC1RT',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.server,
+		category: 'server'
 	}
 ];

--- a/src/lib/data/brandPacks/synology.ts
+++ b/src/lib/data/brandPacks/synology.ts
@@ -129,5 +129,189 @@ export const synologyDevices: DeviceType[] = [
 		is_full_depth: true,
 		colour: CATEGORY_COLOURS.storage,
 		category: 'storage'
+	},
+
+	// Additional devices from NetBox library
+	{
+		slug: 'synology-ds1517-plus',
+		u_height: 4,
+		manufacturer: 'Synology',
+		model: 'DS1517+',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-fs6400',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'FS6400',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs1219-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS1219+',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs1221-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS1221+',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs1221rp-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS1221RP+',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs1619xs-plus',
+		u_height: 1,
+		manufacturer: 'Synology',
+		model: 'RS1619xs+',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs2416rp-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS2416RP+',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs2418-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS2418+',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs2418rp-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS2418RP+',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs2421-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS2421+',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs2421rp-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS2421RP+',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs3614xs-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS3614xs+',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs3617rpxs',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS3617RPxs',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs3621xs-plus',
+		u_height: 2,
+		manufacturer: 'Synology',
+		model: 'RS3621xs+',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs422-plus',
+		u_height: 1,
+		manufacturer: 'Synology',
+		model: 'RS422+',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs815-plus',
+		u_height: 1,
+		manufacturer: 'Synology',
+		model: 'RS815+',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs816',
+		u_height: 1,
+		manufacturer: 'Synology',
+		model: 'RS816',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs819',
+		u_height: 1,
+		manufacturer: 'Synology',
+		model: 'RS819',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs820-plus',
+		u_height: 1,
+		manufacturer: 'Synology',
+		model: 'RS820+',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rs820rp-plus',
+		u_height: 1,
+		manufacturer: 'Synology',
+		model: 'RS820RP+',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
+	},
+	{
+		slug: 'synology-rx1217',
+		u_height: 1,
+		manufacturer: 'Synology',
+		model: 'RX1217',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
 	}
 ];

--- a/src/lib/data/brandPacks/ubiquiti.ts
+++ b/src/lib/data/brandPacks/ubiquiti.ts
@@ -578,5 +578,401 @@ export const ubiquitiDevices: DeviceType[] = [
 		category: 'power',
 		front_image: true,
 		rear_image: true
+	},
+
+	// Additional devices from NetBox library
+	{
+		slug: 'ubiquiti-uacc-rack-panel-patch-blank-24',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: '24-Port Blank Keystone Patch Panel',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-uf-olt',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: '8-Port GPON Optical Line Terminal',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-uacc-ai-port-rm',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'AI Port Rack Mount',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-ckg2-rm',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'CloudKey Rack Mount',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-er-10x',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter 10X',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-er-12',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter 12',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-er-12p',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter 12P',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-er-4',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter 4',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-er-6p',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter 6P',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-er-8',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter 8',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-edgerouter-infinity',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter Infinity',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-erlite-3',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter Lite',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-erpoe-5',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter PoE 5-Port',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-edgerouter-pro',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeRouter Pro',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-16-150w',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeSwitch 16 150W',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-16-xg',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeSwitch 16 XG',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-24-250w',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeSwitch 24 250W',
+		is_full_depth: false,
+		airflow: 'left-to-right',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-24-500w',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeSwitch 24 500W',
+		is_full_depth: false,
+		airflow: 'left-to-right',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-24-lite',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeSwitch 24 Lite',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-48-500w',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeSwitch 48 500W',
+		is_full_depth: false,
+		airflow: 'left-to-right',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-48-750w',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeSwitch 48 750W',
+		is_full_depth: false,
+		airflow: 'left-to-right',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-48-lite',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'EdgeSwitch 48 Lite',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-enterprise-campus-aggregation',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'Enterprise Campus Aggregation',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-enterprise-campus-switch-24-port-poe',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'Enterprise Campus Switch 24-Port PoE',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-enterprise-fortress-gateway',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'Enterprise Fortress Gateway',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-er-x',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'ER-X',
+		is_full_depth: false,
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-er-x-sfp',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'ER-X-SFP',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-10x',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'ES-10X',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-10xp',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'ES-10XP',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-es-12f',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'ES-12F',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-unifi-application-server',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'UniFi Application Server',
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-uc-ck',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'UniFi Cloud Key',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-unifi-switch-16-poe-150w-gen1',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'UniFi Switch 16 PoE 150W Gen1',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-unifi-switch-24-gen1',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'UniFi Switch 24 Gen1',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-unifi-switch-24-poe-250w-gen1',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'UniFi Switch 24 PoE 250W Gen1',
+		is_full_depth: false,
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-unifi-switch-24-poe-500w-gen1',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'UniFi Switch 24 PoE 500W Gen1',
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-unifi-switch-48-poe-500w-gen1',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'UniFi Switch 48 PoE 500W Gen1',
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-unifi-switch-48-poe-750w-gen1',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'UniFi Switch 48 PoE 750W Gen1',
+		airflow: 'side-to-rear',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-usg',
+		u_height: 1,
+		manufacturer: 'Ubiquiti',
+		model: 'USG',
+		is_full_depth: false,
+		airflow: 'passive',
+		colour: CATEGORY_COLOURS.network,
+		category: 'network'
+	},
+	{
+		slug: 'ubiquiti-unas-pro',
+		u_height: 2,
+		manufacturer: 'Ubiquiti',
+		model: 'UNAS Pro',
+		is_full_depth: false,
+		airflow: 'front-to-rear',
+		colour: CATEGORY_COLOURS.storage,
+		category: 'storage'
 	}
 ];

--- a/src/lib/data/starterLibrary.ts
+++ b/src/lib/data/starterLibrary.ts
@@ -1,10 +1,9 @@
 /**
  * Starter Device Type Library
- * Curated selection from NetBox Community Device Type Library
- * https://github.com/netbox-community/devicetype-library
+ * Generic rack devices for quick prototyping and universal fallbacks
  *
- * Total devices: 424
- * Generated: 2025-12-25
+ * Total devices: 43 generic devices (no manufacturer)
+ * All branded devices have been moved to brandPacks/
  */
 
 import type { DeviceType, DeviceCategory } from '$lib/types';
@@ -12,424 +11,65 @@ import { CATEGORY_COLOURS } from '$lib/types/constants';
 
 interface StarterDeviceSpec {
 	slug: string;
-	manufacturer?: string;
 	model: string;
 	u_height: number;
 	category: DeviceCategory;
 	is_full_depth?: boolean;
-	airflow?: string;
-	va_rating?: number;
 }
 
 const STARTER_DEVICES: StarterDeviceSpec[] = [
-	// Servers (113)
+	// Servers (4)
 	{ slug: '1u-server', model: 'Server', u_height: 1, category: 'server' },
 	{ slug: '2u-server', model: 'Server', u_height: 2, category: 'server' },
 	{ slug: '3u-server', model: 'Server', u_height: 3, category: 'server' },
 	{ slug: '4u-server', model: 'Server', u_height: 4, category: 'server' },
-	{ slug: 'dell-poweredge-1950', manufacturer: 'Dell', model: 'PowerEdge 1950', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-c6400', manufacturer: 'Dell', model: 'PowerEdge C6400', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-m1000e', manufacturer: 'Dell', model: 'PowerEdge M1000e', u_height: 10, category: 'server' },
-	{ slug: 'dell-poweredge-mx7000', manufacturer: 'Dell', model: 'PowerEdge MX7000', u_height: 7, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r320', manufacturer: 'Dell', model: 'PowerEdge R320', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r330', manufacturer: 'Dell', model: 'PowerEdge R330', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r340', manufacturer: 'Dell', model: 'PowerEdge R340', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r350', manufacturer: 'Dell', model: 'PowerEdge R350', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r360', manufacturer: 'Dell', model: 'PowerEdge R360', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r420', manufacturer: 'Dell', model: 'PowerEdge R420', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r540', manufacturer: 'Dell', model: 'PowerEdge R540', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r610', manufacturer: 'Dell', model: 'PowerEdge R610', u_height: 1, category: 'server' },
-	{ slug: 'dell-poweredge-r620', manufacturer: 'Dell', model: 'PowerEdge R620', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r630', manufacturer: 'Dell', model: 'PowerEdge R630', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r640', manufacturer: 'Dell', model: 'PowerEdge R640', u_height: 1, category: 'server' },
-	{ slug: 'dell-poweredge-r650', manufacturer: 'Dell', model: 'PowerEdge R650', u_height: 1, category: 'server' },
-	{ slug: 'dell-poweredge-r650xs', manufacturer: 'Dell', model: 'PowerEdge R650xs', u_height: 1, category: 'server' },
-	{ slug: 'dell-poweredge-r6515', manufacturer: 'Dell', model: 'PowerEdge R6515', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r6525', manufacturer: 'Dell', model: 'PowerEdge R6525', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r660', manufacturer: 'Dell', model: 'PowerEdge R660', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r660xs', manufacturer: 'Dell', model: 'PowerEdge R660xs', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r6615', manufacturer: 'Dell', model: 'PowerEdge R6615', u_height: 1, category: 'server' },
-	{ slug: 'dell-poweredge-r6625', manufacturer: 'Dell', model: 'PowerEdge R6625', u_height: 1, category: 'server' },
-	{ slug: 'dell-poweredge-r6715', manufacturer: 'Dell', model: 'PowerEdge R6715', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r6725', manufacturer: 'Dell', model: 'PowerEdge R6725', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r720', manufacturer: 'Dell', model: 'PowerEdge R720', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r720xd', manufacturer: 'Dell', model: 'PowerEdge R720xd', u_height: 2, category: 'server' },
-	{ slug: 'dell-poweredge-r730', manufacturer: 'Dell', model: 'PowerEdge R730', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r730xd', manufacturer: 'Dell', model: 'PowerEdge R730xd', u_height: 2, category: 'server' },
-	{ slug: 'dell-poweredge-r740', manufacturer: 'Dell', model: 'PowerEdge R740', u_height: 2, category: 'server' },
-	{ slug: 'dell-poweredge-r740xd', manufacturer: 'Dell', model: 'PowerEdge R740xd', u_height: 2, category: 'server' },
-	{ slug: 'dell-poweredge-r740xd2', manufacturer: 'Dell', model: 'PowerEdge R740xd2', u_height: 2, category: 'server' },
-	{ slug: 'dell-poweredge-r750xs', manufacturer: 'Dell', model: 'PowerEdge R750xs', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r7515', manufacturer: 'Dell', model: 'PowerEdge R7515', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r7525', manufacturer: 'Dell', model: 'PowerEdge R7525', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r7615', manufacturer: 'Dell', model: 'PowerEdge R7615', u_height: 2, category: 'server' },
-	{ slug: 'dell-poweredge-r7625', manufacturer: 'Dell', model: 'PowerEdge R7625', u_height: 2, category: 'server' },
-	{ slug: 'dell-poweredge-r7715', manufacturer: 'Dell', model: 'PowerEdge R7715', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r7725', manufacturer: 'Dell', model: 'PowerEdge R7725', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'dell-poweredge-r815', manufacturer: 'Dell', model: 'PowerEdge R815', u_height: 2, category: 'server' },
-	{ slug: 'dell-poweredge-r940', manufacturer: 'Dell', model: 'PowerEdge R940', u_height: 3, category: 'server' },
-	{ slug: 'dell-poweredge-t630', manufacturer: 'Dell', model: 'PowerEdge T630', u_height: 5, category: 'server' },
-	{ slug: 'dell-poweredge-t640', manufacturer: 'Dell', model: 'PowerEdge T640', u_height: 5, category: 'server' },
-	{ slug: 'hpe-proliant-dl180-gen6', manufacturer: 'HPE', model: 'ProLiant DL180 Gen6', u_height: 2, category: 'server' },
-	{ slug: 'hpe-proliant-dl20-gen10', manufacturer: 'HPE', model: 'ProLiant DL20 Gen10', u_height: 1, category: 'server' },
-	{ slug: 'hpe-proliant-dl20-gen11', manufacturer: 'HPE', model: 'ProLiant DL20 Gen11', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl325-gen10', manufacturer: 'HPE', model: 'ProLiant DL325 Gen10', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl325-gen10-plus', manufacturer: 'HPE', model: 'ProLiant DL325 Gen10 Plus', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl325-gen10-plus-v2', manufacturer: 'HPE', model: 'ProLiant DL325 Gen10 Plus v2', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl325-gen11', manufacturer: 'HPE', model: 'ProLiant DL325 Gen11', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl345-gen11', manufacturer: 'HPE', model: 'ProLiant DL345 Gen11', u_height: 2, category: 'server' },
-	{ slug: 'hpe-proliant-dl360-gen10', manufacturer: 'HPE', model: 'ProLiant DL360 Gen10', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl360-gen10-plus', manufacturer: 'HPE', model: 'ProLiant DL360 Gen10 Plus', u_height: 1, category: 'server' },
-	{ slug: 'hpe-proliant-dl360-gen11', manufacturer: 'HPE', model: 'ProLiant DL360 Gen11', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl360-gen7', manufacturer: 'HPE', model: 'ProLiant DL360 Gen7', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl360-gen9', manufacturer: 'HPE', model: 'ProLiant DL360 Gen9', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl360e-gen8', manufacturer: 'HPE', model: 'ProLiant DL360e Gen8', u_height: 1, category: 'server' },
-	{ slug: 'hpe-proliant-dl360p-gen8', manufacturer: 'HPE', model: 'ProLiant DL360p Gen8', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl365-gen11', manufacturer: 'HPE', model: 'ProLiant DL365 Gen11', u_height: 1, category: 'server' },
-	{ slug: 'hpe-proliant-dl380-gen10', manufacturer: 'HPE', model: 'ProLiant DL380 Gen10', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl380-gen10-plus', manufacturer: 'HPE', model: 'ProLiant DL380 Gen10 Plus', u_height: 2, category: 'server' },
-	{ slug: 'hpe-proliant-dl380-gen11', manufacturer: 'HPE', model: 'ProLiant DL380 Gen11', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl380-gen5', manufacturer: 'HPE', model: 'ProLiant DL380 Gen5', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl380-gen9', manufacturer: 'HPE', model: 'ProLiant DL380 Gen9', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl380e-gen8', manufacturer: 'HPE', model: 'ProLiant DL380e Gen8', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl380p-gen8', manufacturer: 'HPE', model: 'ProLiant DL380p Gen8', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl385-gen10-plus-v2', manufacturer: 'HPE', model: 'ProLiant DL385 Gen10 Plus v2', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl385-gen11', manufacturer: 'HPE', model: 'ProLiant DL385 Gen11', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl385p-gen8', manufacturer: 'HPE', model: 'ProLiant DL385p Gen8', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl560-gen10', manufacturer: 'HPE', model: 'ProLiant DL560 Gen10', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl580-gen10', manufacturer: 'HPE', model: 'ProLiant DL580 Gen10', u_height: 4, category: 'server' },
-	{ slug: 'hpe-proliant-dl580-gen9', manufacturer: 'HPE', model: 'ProLiant DL580 Gen9', u_height: 4, category: 'server' },
-	{ slug: 'hpe-proliant-dx360-gen10', manufacturer: 'HPE', model: 'ProLiant DX360 Gen10', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dx385-gen10-plus', manufacturer: 'HPE', model: 'ProLiant DX385 Gen10 Plus', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dx385-gen10-plus-v2', manufacturer: 'HPE', model: 'ProLiant DX385 Gen10 Plus V2', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-ml110-gen10', manufacturer: 'HPE', model: 'ProLiant ML110 Gen10', u_height: 3, category: 'server' },
-	{ slug: 'hpe-proliant-ml110-gen9', manufacturer: 'HPE', model: 'ProLiant ML110 Gen9', u_height: 3, category: 'server' },
-	{ slug: 'hpe-proliant-ml30-gen10-plus', manufacturer: 'HPE', model: 'ProLiant ML30 Gen10 Plus', u_height: 4, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-ml350-gen10', manufacturer: 'HPE', model: 'ProLiant ML350 Gen10', u_height: 4, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-ml350-gen9', manufacturer: 'HPE', model: 'ProLiant ML350 Gen9', u_height: 4, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-ml350p-gen8', manufacturer: 'HPE', model: 'ProLiant ML350p Gen8', u_height: 4, category: 'server' },
-	{ slug: 'hpe-proliant-xl420-gen9', manufacturer: 'HPE', model: 'ProLiant XL420 Gen9', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'hpe-proliant-dl120-gen7', manufacturer: 'HPE', model: 'ProLiant-DL120-Gen7', u_height: 1, category: 'server' },
-	{ slug: 'hpe-proliant-dl320-gen6', manufacturer: 'HPE', model: 'ProLiant-DL320-Gen6', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'lenovo-thinksystem-sr250-v2', manufacturer: 'Lenovo', model: 'ThinkSystem SR250 V2', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'lenovo-thinksystem-sr530', manufacturer: 'Lenovo', model: 'ThinkSystem SR530', u_height: 1, category: 'server' },
-	{ slug: 'lenovo-thinksystem-sr550', manufacturer: 'Lenovo', model: 'ThinkSystem SR550', u_height: 2, category: 'server' },
-	{ slug: 'lenovo-thinksystem-sr630', manufacturer: 'Lenovo', model: 'ThinkSystem SR630', u_height: 1, category: 'server' },
-	{ slug: 'lenovo-thinksystem-sr635', manufacturer: 'Lenovo', model: 'ThinkSystem SR635', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'lenovo-thinksystem-sr645', manufacturer: 'Lenovo', model: 'ThinkSystem SR645', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'lenovo-thinksystem-sr650', manufacturer: 'Lenovo', model: 'ThinkSystem SR650', u_height: 2, category: 'server' },
-	{ slug: 'lenovo-thinksystem-sr650-v2', manufacturer: 'Lenovo', model: 'ThinkSystem SR650 V2', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'lenovo-thinksystem-sr655-v3', manufacturer: 'Lenovo', model: 'ThinkSystem SR655 V3', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'lenovo-thinksystem-sr665-v3', manufacturer: 'Lenovo', model: 'ThinkSystem SR665 V3', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-as-2124bt-hntr', manufacturer: 'Supermicro', model: 'A+ Server 2124BT-HNTR', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-asg-2015s-e1cr24l', manufacturer: 'Supermicro', model: 'ASG-2015S-E1CR24L', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-as-3015mr-h8tnr', manufacturer: 'Supermicro', model: 'MicroCloud A+ Server AS 3015MR-H8TNR', u_height: 3, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-sse-g3648b', manufacturer: 'Supermicro', model: 'SSE-G3648B', u_height: 1, category: 'server', is_full_depth: false },
-	{ slug: 'supermicro-ssg-610p-acr12n4h', manufacturer: 'Supermicro', model: 'Storage SuperServer SSG-610P-ACR12N4H', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-storage-superserver-ssg-620p-e1cr24l', manufacturer: 'Supermicro', model: 'Storage SuperServer SSG-620P-E1CR24L', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-ssg-640p-e1cr36l', manufacturer: 'Supermicro', model: 'Storage SuperServer SSG-640P-E1CR36L', u_height: 4, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-sse-x3348tr', manufacturer: 'Supermicro', model: 'Supermicro SSE-X3348TR', u_height: 1, category: 'server' },
-	{ slug: 'supermicro-sys-1029u-tr4t', manufacturer: 'Supermicro', model: 'SuperServer 1029U-TR4T', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-as-1014s-wtrt', manufacturer: 'Supermicro', model: 'SuperServer A+ Server 1014S-WTRT', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-sys-110p-wtr', manufacturer: 'Supermicro', model: 'SuperServer SYS-110P-WTR', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-superstorage-6027r-e1r12n', manufacturer: 'Supermicro', model: 'SuperStorage 6027R-E1R12N', u_height: 2, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-superstorage-6038r-e1cr16h', manufacturer: 'Supermicro', model: 'SuperStorage 6038r-E1CR16H', u_height: 3, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-sys-1019p-wtr', manufacturer: 'Supermicro', model: 'SYS-1019P-WTR', u_height: 1, category: 'server', airflow: 'front-to-rear' },
-	{ slug: 'supermicro-sys-1028r-wc1rt', manufacturer: 'Supermicro', model: 'SYS-1028R-WC1RT', u_height: 1, category: 'server', airflow: 'front-to-rear' },
 
-	// Networking (164)
+	// Network (4)
 	{ slug: '1u-router-firewall', model: 'Router/Firewall', u_height: 1, category: 'network' },
 	{ slug: '2u-router-firewall', model: 'Router/Firewall', u_height: 2, category: 'network' },
 	{ slug: '24-port-switch', model: 'Switch (24-Port)', u_height: 1, category: 'network' },
 	{ slug: '48-port-switch', model: 'Switch (48-Port)', u_height: 1, category: 'network' },
-	{ slug: 'fortinet-fg-1000d', manufacturer: 'Fortinet', model: 'FortiGate 1000D', u_height: 2, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'fortinet-fg-100d', manufacturer: 'Fortinet', model: 'FortiGate 100D', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'fortinet-fg-100e', manufacturer: 'Fortinet', model: 'FortiGate 100E', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'fortinet-fg-100ef', manufacturer: 'Fortinet', model: 'FortiGate 100EF', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'fortinet-fg-100f', manufacturer: 'Fortinet', model: 'FortiGate 100F', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'fortinet-fg-1100e', manufacturer: 'Fortinet', model: 'FortiGate 1100E', u_height: 2, category: 'network', is_full_depth: false },
-	{ slug: 'fortinet-fg-1200d', manufacturer: 'Fortinet', model: 'FortiGate 1200D', u_height: 2, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'fortinet-fg-1800f', manufacturer: 'Fortinet', model: 'FortiGate 1800F', u_height: 2, category: 'network', airflow: 'front-to-rear' },
-	{ slug: 'fortinet-fg-1801f', manufacturer: 'Fortinet', model: 'FortiGate 1801F', u_height: 2, category: 'network', airflow: 'front-to-rear' },
-	{ slug: 'fortinet-fg-200d', manufacturer: 'Fortinet', model: 'FortiGate 200D', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'fortinet-fg-200e', manufacturer: 'Fortinet', model: 'FortiGate 200E', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'fortinet-fg-200f', manufacturer: 'Fortinet', model: 'FortiGate 200F', u_height: 1, category: 'network', airflow: 'side-to-rear' },
-	{ slug: 'fortinet-fg-200g', manufacturer: 'Fortinet', model: 'FortiGate 200G', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'fortinet-fg-2200e', manufacturer: 'Fortinet', model: 'FortiGate 2200E', u_height: 2, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'fortinet-fg-2600f', manufacturer: 'Fortinet', model: 'FortiGate 2600F', u_height: 2, category: 'network', airflow: 'front-to-rear' },
-	{ slug: 'fortinet-fg-3200d', manufacturer: 'Fortinet', model: 'FortiGate 3200D', u_height: 2, category: 'network', airflow: 'front-to-rear' },
-	{ slug: 'fortinet-fg-600e', manufacturer: 'Fortinet', model: 'FortiGate 600E', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'fortinet-fg-600f', manufacturer: 'Fortinet', model: 'FortiGate 600F', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'fortinet-fg-601e', manufacturer: 'Fortinet', model: 'FortiGate 601E', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'fortinet-fg-600d', manufacturer: 'Fortinet', model: 'FortiGate-600D', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-ccr1009-7g-1c-1s-plus', manufacturer: 'MikroTik', model: 'CCR1009-7G-1C-1S+', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'mikrotik-ccr1009-7g-1c-1s-plus-pc', manufacturer: 'MikroTik', model: 'CCR1009-7G-1C-1S+PC', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'mikrotik-ccr1009-7g-1c-pc', manufacturer: 'MikroTik', model: 'CCR1009-7G-1C-PC', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-ccr1009-8g-1s-1s-plus', manufacturer: 'MikroTik', model: 'CCR1009-8G-1S-1S+', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-ccr1016-12g', manufacturer: 'MikroTik', model: 'CCR1016-12G', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-ccr1016-12s-1s-plus', manufacturer: 'MikroTik', model: 'CCR1016-12S-1S+', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'mikrotik-ccr1016-12s-1s-plus-r2', manufacturer: 'MikroTik', model: 'CCR1016-12S-1S+-r2', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'mikrotik-ccr1036-12g-4s', manufacturer: 'MikroTik', model: 'CCR1036-12G-4S', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-ccr1036-12g-4s-em', manufacturer: 'MikroTik', model: 'CCR1036-12G-4S-EM', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-ccr1036-8g-2s-plus', manufacturer: 'MikroTik', model: 'CCR1036-8G-2S+', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'mikrotik-ccr1036-8g-2s-plus-em', manufacturer: 'MikroTik', model: 'CCR1036-8G-2S+EM', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'mikrotik-ccr1072-1g-8s-plus', manufacturer: 'MikroTik', model: 'CCR1072-1G-8S+', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-ccr2004-16g-2s-plus', manufacturer: 'MikroTik', model: 'CCR2004-16G-2S+', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'mikrotik-ccr2004-1g-12s-plus-2xs', manufacturer: 'MikroTik', model: 'CCR2004-1G-12S+2XS', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-ccr2116-12g-4s-plus', manufacturer: 'MikroTik', model: 'CCR2116-12G-4S+', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-ccr2216-1g-12xs-2xq', manufacturer: 'MikroTik', model: 'CCR2216-1G-12XS-2XQ', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs305-1g-4s-plus-in', manufacturer: 'MikroTik', model: 'CRS305-1G-4S+IN', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs309-1g-8s-plus-in', manufacturer: 'MikroTik', model: 'CRS309-1G-8S+IN', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs310-1g-5s-4s-plus-in', manufacturer: 'MikroTik', model: 'CRS310-1G-5S-4S+IN', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs310-8g-plus-2s-plus-in', manufacturer: 'MikroTik', model: 'CRS310-8G+2S+IN', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'mikrotik-crs312-4c-plus-8xg-rm', manufacturer: 'MikroTik', model: 'CRS312-4C+8XG-RM', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs317-1g-16s-plus-rm', manufacturer: 'MikroTik', model: 'CRS317-1G-16S+RM', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs320-8p-8b-4s-plus-rm', manufacturer: 'MikroTik', model: 'CRS320-8P-8B-4S+RM', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'mikrotik-crs326-24g-2s-plus-rm', manufacturer: 'MikroTik', model: 'CRS326-24G-2S+RM', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'mikrotik-crs326-24s-plus-2q-plus-rm', manufacturer: 'MikroTik', model: 'CRS326-24S+2Q+RM', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs326-4c-plus-20g-plus-2q-plus-rm', manufacturer: 'MikroTik', model: 'CRS326-4C+20G+2Q+RM', u_height: 1, category: 'network', is_full_depth: false, airflow: 'mixed' },
-	{ slug: 'mikrotik-crs328-24p-4s-plus-rm', manufacturer: 'MikroTik', model: 'CRS328-24P-4S+RM', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs328-4c-20s-4s-plus-rm', manufacturer: 'MikroTik', model: 'CRS328-4C-20S-4S+RM', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs354-48g-4s-plus-2q-plus-rm', manufacturer: 'MikroTik', model: 'CRS354-48G-4S+2Q+RM', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'mikrotik-crs354-48p-4s-plus-2q-plus-rm', manufacturer: 'MikroTik', model: 'CRS354-48P-4S+2Q+RM', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgate-1100-security-gateway', manufacturer: 'Netgate', model: '1100 Security Gateway', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'netgate-1537-security-gateway', manufacturer: 'Netgate', model: '1537 Security Gateway', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'netgate-3100-security-gateway', manufacturer: 'Netgate', model: '3100 Security Gateway', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'netgate-4100-security-gateway', manufacturer: 'Netgate', model: '4100 Security Gateway', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'netgate-6100-security-gateway', manufacturer: 'Netgate', model: '6100 Security Gateway', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'netgate-7100-security-gateway', manufacturer: 'Netgate', model: '7100 Security Gateway', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgate-8200-max-pfsense-plus-security-gateway', manufacturer: 'Netgate', model: '8200 Max PFSense+ Security Gateway', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'netgate-8300-security-gateway', manufacturer: 'Netgate', model: '8300 Security Gateway', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'netgear-gs105', manufacturer: 'Netgear', model: 'GS105', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-gs105e', manufacturer: 'Netgear', model: 'GS105E', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-gs108', manufacturer: 'Netgear', model: 'GS108', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-gs108e', manufacturer: 'Netgear', model: 'GS108E', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-gs108lp', manufacturer: 'Netgear', model: 'GS108LP', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'netgear-gs108pp', manufacturer: 'Netgear', model: 'GS108PP', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'netgear-gs110emx', manufacturer: 'Netgear', model: 'GS110EMX', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'netgear-gs116', manufacturer: 'Netgear', model: 'GS116', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-gs116ev2', manufacturer: 'Netgear', model: 'GS116Ev2', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-gs324tp', manufacturer: 'Netgear', model: 'GS324TP', u_height: 1, category: 'network', is_full_depth: false, airflow: 'left-to-right' },
-	{ slug: 'netgear-gs724t', manufacturer: 'Netgear', model: 'GS724T', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'netgear-prosafe-gsm7328fs', manufacturer: 'Netgear', model: 'ProSafe GSM7328FS', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-prosafe-gsm7228s', manufacturer: 'Netgear', model: 'ProSafe M5300-28G (GSM7228S)', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-prosafe-gsm7228ps', manufacturer: 'Netgear', model: 'ProSafe M5300-28G-POE+ (GSM7228PS)', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-prosafe-gsm7252s', manufacturer: 'Netgear', model: 'ProSafe M5300-52G (GSM7252S)', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-prosafe-gsm7252ps', manufacturer: 'Netgear', model: 'ProSafe M5300-52G-POE+ (GSM7252PS)', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'netgear-s3300-28x-poep', manufacturer: 'Netgear', model: 'S3300-28X-PoE+', u_height: 1, category: 'network', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'netgear-s3300-52x', manufacturer: 'Netgear', model: 'S3300-52X', u_height: 1, category: 'network', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'palo-alto-pa-1410', manufacturer: 'Palo Alto', model: 'PA-1410', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'palo-alto-pa-1420', manufacturer: 'Palo Alto', model: 'PA-1420', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'palo-alto-pa-200', manufacturer: 'Palo Alto', model: 'PA-200', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'palo-alto-pa-220-rack-kit', manufacturer: 'Palo Alto', model: 'PA-220 Rack Kit', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'palo-alto-pa-220-rack-tray-kit', manufacturer: 'Palo Alto', model: 'PA-220 Rack Tray Kit', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'palo-alto-pa-3020', manufacturer: 'Palo Alto', model: 'PA-3020', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'palo-alto-pa-3050', manufacturer: 'Palo Alto', model: 'PA-3050', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'palo-alto-pa-3060', manufacturer: 'Palo Alto', model: 'PA-3060', u_height: 2, category: 'network' },
-	{ slug: 'palo-alto-pa-3220', manufacturer: 'Palo Alto', model: 'PA-3220', u_height: 2, category: 'network' },
-	{ slug: 'palo-alto-pa-3250', manufacturer: 'Palo Alto', model: 'PA-3250', u_height: 2, category: 'network' },
-	{ slug: 'palo-alto-pa-3260', manufacturer: 'Palo Alto', model: 'PA-3260', u_height: 2, category: 'network' },
-	{ slug: 'palo-alto-pa-3410', manufacturer: 'Palo Alto', model: 'PA-3410', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'palo-alto-pa-3420', manufacturer: 'Palo Alto', model: 'PA-3420', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'palo-alto-pa-3430', manufacturer: 'Palo Alto', model: 'PA-3430', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'palo-alto-pa-3440', manufacturer: 'Palo Alto', model: 'PA-3440', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'tp-link-er605-v2', manufacturer: 'TP-Link', model: 'ER605-V2', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'tp-link-er707-m2', manufacturer: 'TP-Link', model: 'ER707-M2', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'tp-link-er7206', manufacturer: 'TP-Link', model: 'ER7206', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'tp-link-oc200', manufacturer: 'TP-Link', model: 'OC200', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'tp-link-oc300', manufacturer: 'TP-Link', model: 'OC300', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'tp-link-tl-sg2428p', manufacturer: 'TP-Link', model: 'SG2428P', u_height: 1, category: 'network', is_full_depth: false, airflow: 'left-to-right' },
-	{ slug: 'tp-link-t1500g-10mbps', manufacturer: 'TP-Link', model: 'T1500g-10MPS', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'tp-link-t2500g-10ts', manufacturer: 'TP-Link', model: 'T2500G-10TS', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'tp-link-t2600g-28mps', manufacturer: 'TP-Link', model: 'T2600G-28MPS', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'tp-link-t2600g-28ts', manufacturer: 'TP-Link', model: 'T2600G-28TS', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'tp-link-t2600g-52ts', manufacturer: 'TP-Link', model: 'T2600G-52TS', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'tp-link-td-w8950n', manufacturer: 'TP-Link', model: 'TD-W8950N', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'tp-link-tl-se2109pb', manufacturer: 'TP-Link', model: 'TL-SE2109PB', u_height: 1, category: 'network', is_full_depth: false, airflow: 'left-to-right' },
-	{ slug: 'tp-link-tl-sg1008mp', manufacturer: 'TP-Link', model: 'TL-SG1008MP', u_height: 1, category: 'network', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'tp-link-tl-sg1016de', manufacturer: 'TP-Link', model: 'TL-SG1016DE', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'tp-link-tl-sg1016pe', manufacturer: 'TP-Link', model: 'TL-SG1016PE', u_height: 1, category: 'network', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'tp-link-tl-sg1024d', manufacturer: 'TP-Link', model: 'TL-SG1024D', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'tp-link-tl-sg1218mpe', manufacturer: 'TP-Link', model: 'TL-SG1218MPE', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'tp-link-sg2210mp', manufacturer: 'TP-Link', model: 'TL-SG2210MP', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'tp-link-tl-sg3210', manufacturer: 'TP-Link', model: 'TL-SG3210', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-uacc-rack-panel-patch-blank-24', manufacturer: 'Ubiquiti', model: '24-Port Blank Keystone Patch Panel', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-uf-olt', manufacturer: 'Ubiquiti', model: '8-Port GPON Optical Line Terminal', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-uacc-ai-port-rm', manufacturer: 'Ubiquiti', model: 'AI Port Rack Mount', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-ckg2-rm', manufacturer: 'Ubiquiti', model: 'CloudKey Rack Mount', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-er-10x', manufacturer: 'Ubiquiti', model: 'EdgeRouter 10X', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-er-12', manufacturer: 'Ubiquiti', model: 'EdgeRouter 12', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-er-12p', manufacturer: 'Ubiquiti', model: 'EdgeRouter 12P', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-er-4', manufacturer: 'Ubiquiti', model: 'EdgeRouter 4', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-er-6p', manufacturer: 'Ubiquiti', model: 'EdgeRouter 6P', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-er-8', manufacturer: 'Ubiquiti', model: 'EdgeRouter 8', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-edgerouter-infinity', manufacturer: 'Ubiquiti', model: 'EdgeRouter Infinity', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-erlite-3', manufacturer: 'Ubiquiti', model: 'EdgeRouter Lite', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-erpoe-5', manufacturer: 'Ubiquiti', model: 'EdgeRouter PoE 5-Port', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-edgerouter-pro', manufacturer: 'Ubiquiti', model: 'EdgeRouter Pro', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-es-16-150w', manufacturer: 'Ubiquiti', model: 'EdgeSwitch 16 150W', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-es-16-xg', manufacturer: 'Ubiquiti', model: 'EdgeSwitch 16 XG', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-es-24-250w', manufacturer: 'Ubiquiti', model: 'EdgeSwitch 24 250W', u_height: 1, category: 'network', is_full_depth: false, airflow: 'left-to-right' },
-	{ slug: 'ubiquiti-es-24-500w', manufacturer: 'Ubiquiti', model: 'EdgeSwitch 24 500W', u_height: 1, category: 'network', is_full_depth: false, airflow: 'left-to-right' },
-	{ slug: 'ubiquiti-es-24-lite', manufacturer: 'Ubiquiti', model: 'EdgeSwitch 24 Lite', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-es-48-500w', manufacturer: 'Ubiquiti', model: 'EdgeSwitch 48 500W', u_height: 1, category: 'network', is_full_depth: false, airflow: 'left-to-right' },
-	{ slug: 'ubiquiti-es-48-750w', manufacturer: 'Ubiquiti', model: 'EdgeSwitch 48 750W', u_height: 1, category: 'network', is_full_depth: false, airflow: 'left-to-right' },
-	{ slug: 'ubiquiti-es-48-lite', manufacturer: 'Ubiquiti', model: 'EdgeSwitch 48 Lite', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-enterprise-campus-aggregation', manufacturer: 'Ubiquiti', model: 'Enterprise Campus Aggregation', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-enterprise-campus-switch-24-port-poe', manufacturer: 'Ubiquiti', model: 'Enterprise Campus Switch 24-Port PoE', u_height: 1, category: 'network', airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-enterprise-fortress-gateway', manufacturer: 'Ubiquiti', model: 'Enterprise Fortress Gateway', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-enterprise-network-video-recorder', manufacturer: 'Ubiquiti', model: 'Enterprise Network Video Recorder', u_height: 4, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-er-x', manufacturer: 'Ubiquiti', model: 'ER-X', u_height: 1, category: 'network', is_full_depth: false },
-	{ slug: 'ubiquiti-er-x-sfp', manufacturer: 'Ubiquiti', model: 'ER-X-SFP', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-es-10x', manufacturer: 'Ubiquiti', model: 'ES-10X', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-es-10xp', manufacturer: 'Ubiquiti', model: 'ES-10XP', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-es-12f', manufacturer: 'Ubiquiti', model: 'ES-12F', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-unifi-application-server', manufacturer: 'Ubiquiti', model: 'UniFi Application Server', u_height: 1, category: 'network', airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-uc-ck', manufacturer: 'Ubiquiti', model: 'UniFi Cloud Key', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-unifi-dream-machine-pro', manufacturer: 'Ubiquiti', model: 'UniFi Dream Machine Pro', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-unifi-dream-machine-pro-max', manufacturer: 'Ubiquiti', model: 'UniFi Dream Machine Pro Max', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-unifi-dream-machine-pro-special-edition', manufacturer: 'Ubiquiti', model: 'UniFi Dream Machine Pro Special Edition', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-unifi-protect-network-video-recorder', manufacturer: 'Ubiquiti', model: 'UniFi Protect Network Video Recorder', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-unifi-protect-network-video-recorder-pro', manufacturer: 'Ubiquiti', model: 'UniFi Protect Network Video Recorder Pro', u_height: 2, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-unifi-security-gateway-pro', manufacturer: 'Ubiquiti', model: 'UniFi Security Gateway Pro', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-unifi-switch-16-poe-150w-gen1', manufacturer: 'Ubiquiti', model: 'UniFi Switch 16 PoE 150W Gen1', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-unifi-switch-16-xg', manufacturer: 'Ubiquiti', model: 'UniFi Switch 16 XG', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-unifi-switch-24-gen1', manufacturer: 'Ubiquiti', model: 'UniFi Switch 24 Gen1', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-unifi-switch-24-poe-250w-gen1', manufacturer: 'Ubiquiti', model: 'UniFi Switch 24 PoE 250W Gen1', u_height: 1, category: 'network', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-unifi-switch-24-poe-500w-gen1', manufacturer: 'Ubiquiti', model: 'UniFi Switch 24 PoE 500W Gen1', u_height: 1, category: 'network', airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-unifi-switch-48-gen1', manufacturer: 'Ubiquiti', model: 'UniFi Switch 48 Gen1', u_height: 1, category: 'network', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'ubiquiti-unifi-switch-48-poe-500w-gen1', manufacturer: 'Ubiquiti', model: 'UniFi Switch 48 PoE 500W Gen1', u_height: 1, category: 'network', airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-unifi-switch-48-poe-750w-gen1', manufacturer: 'Ubiquiti', model: 'UniFi Switch 48 PoE 750W Gen1', u_height: 1, category: 'network', airflow: 'side-to-rear' },
-	{ slug: 'ubiquiti-unifi-switch-xg-6poe', manufacturer: 'Ubiquiti', model: 'UniFi Switch XG 6PoE', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'ubiquiti-usg', manufacturer: 'Ubiquiti', model: 'USG', u_height: 1, category: 'network', is_full_depth: false, airflow: 'passive' },
 
-	// Storage/NAS (39)
+	// Storage (4)
 	{ slug: '1u-storage', model: 'Storage', u_height: 1, category: 'storage' },
 	{ slug: '2u-storage', model: 'Storage', u_height: 2, category: 'storage' },
 	{ slug: '3u-storage', model: 'Storage', u_height: 3, category: 'storage' },
 	{ slug: '4u-storage', model: 'Storage', u_height: 4, category: 'storage' },
-	{ slug: 'qnap-ts-1263u-rp', manufacturer: 'QNAP', model: 'TS-1263U-RP', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'qnap-ts-1683xu-rp', manufacturer: 'QNAP', model: 'TS-1683XU-RP', u_height: 3, category: 'storage' },
-	{ slug: 'qnap-ts-431u', manufacturer: 'QNAP', model: 'TS-431U', u_height: 1, category: 'storage', is_full_depth: false, airflow: 'side-to-rear' },
-	{ slug: 'qnap-ts-432pxu', manufacturer: 'QNAP', model: 'TS-432PXU', u_height: 1, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'qnap-ts-432pxu-rp', manufacturer: 'QNAP', model: 'TS-432PXU-RP', u_height: 1, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'qnap-ts-463u-rp', manufacturer: 'QNAP', model: 'TS-463U-RP', u_height: 1, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'qnap-ts-832pxu-rp', manufacturer: 'QNAP', model: 'TS-832PXU-RP', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'qnap-ts-873aeu', manufacturer: 'QNAP', model: 'TS-873AeU', u_height: 2, category: 'storage', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'qnap-ts-879u-rp', manufacturer: 'QNAP', model: 'TS-879U-RP', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'qnap-ts-883xu-rp', manufacturer: 'QNAP', model: 'TS-883XU-RP', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'qnap-ts-ec1280u', manufacturer: 'QNAP', model: 'TS-EC1280U', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'qnap-ts-h1886xu-rp', manufacturer: 'QNAP', model: 'TS-h1886XU-RP', u_height: 2, category: 'storage' },
-	{ slug: 'qnap-tvs-ec1580mu-sas-rp', manufacturer: 'QNAP', model: 'TVS-EC1580MU-SAS-RP', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-ds1517-plus', manufacturer: 'Synology', model: 'DS1517+', u_height: 4, category: 'storage', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'synology-fs6400', manufacturer: 'Synology', model: 'FS6400', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rs1219-plus', manufacturer: 'Synology', model: 'RS1219+', u_height: 2, category: 'storage' },
-	{ slug: 'synology-rs1221-plus', manufacturer: 'Synology', model: 'RS1221+', u_height: 2, category: 'storage' },
-	{ slug: 'synology-rs1221rp-plus', manufacturer: 'Synology', model: 'RS1221RP+', u_height: 2, category: 'storage' },
-	{ slug: 'synology-rs1619xs-plus', manufacturer: 'Synology', model: 'RS1619xs+', u_height: 1, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rs2416rp-plus', manufacturer: 'Synology', model: 'RS2416RP+', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rs2418-plus', manufacturer: 'Synology', model: 'RS2418+', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rs2418rp-plus', manufacturer: 'Synology', model: 'RS2418RP+', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rs2421-plus', manufacturer: 'Synology', model: 'RS2421+', u_height: 2, category: 'storage' },
-	{ slug: 'synology-rs2421rp-plus', manufacturer: 'Synology', model: 'RS2421RP+', u_height: 2, category: 'storage' },
-	{ slug: 'synology-rs3614xs-plus', manufacturer: 'Synology', model: 'RS3614xs+', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rs3617rpxs', manufacturer: 'Synology', model: 'RS3617RPxs', u_height: 2, category: 'storage' },
-	{ slug: 'synology-rs3621xs-plus', manufacturer: 'Synology', model: 'RS3621xs+', u_height: 2, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rs422-plus', manufacturer: 'Synology', model: 'RS422+', u_height: 1, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rs815-plus', manufacturer: 'Synology', model: 'RS815+', u_height: 1, category: 'storage' },
-	{ slug: 'synology-rs816', manufacturer: 'Synology', model: 'RS816', u_height: 1, category: 'storage' },
-	{ slug: 'synology-rs819', manufacturer: 'Synology', model: 'RS819', u_height: 1, category: 'storage', is_full_depth: false, airflow: 'front-to-rear' },
-	{ slug: 'synology-rs820-plus', manufacturer: 'Synology', model: 'RS820+', u_height: 1, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rs820rp-plus', manufacturer: 'Synology', model: 'RS820RP+', u_height: 1, category: 'storage', airflow: 'front-to-rear' },
-	{ slug: 'synology-rx1217', manufacturer: 'Synology', model: 'RX1217', u_height: 1, category: 'storage' },
-	{ slug: 'ubiquiti-unas-pro', manufacturer: 'Ubiquiti', model: 'UNAS Pro', u_height: 2, category: 'storage', is_full_depth: false, airflow: 'front-to-rear' },
 
-	// Power (74)
+	// Power (4)
 	{ slug: '1u-pdu', model: 'PDU', u_height: 1, category: 'power', is_full_depth: false },
 	{ slug: '2u-pdu', model: 'PDU', u_height: 2, category: 'power', is_full_depth: false },
 	{ slug: '2u-ups', model: 'UPS', u_height: 2, category: 'power' },
 	{ slug: '4u-ups', model: 'UPS', u_height: 4, category: 'power' },
-	{ slug: 'apc-ap4421', manufacturer: 'APC', model: 'AP4421', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'apc-ap4421a', manufacturer: 'APC', model: 'AP4421A', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'apc-ap4422a', manufacturer: 'APC', model: 'AP4422A', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'apc-ap4423', manufacturer: 'APC', model: 'AP4423', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'apc-ap4423a', manufacturer: 'APC', model: 'AP4423A', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'apc-srt72rmbp', manufacturer: 'APC', model: 'APC Smart-UPS SRT, 72 V, 2,2 kVA, Rackmount Battery Module', u_height: 2, category: 'power' },
-	{ slug: 'apc-smt1500rm2u', manufacturer: 'APC', model: 'Smart-UPS SMT1500RM2U', u_height: 2, category: 'power' },
-	{ slug: 'apc-smart-ups-srt-2200va-rm', manufacturer: 'APC', model: 'Smart-UPS SRT 2200VA RM', u_height: 2, category: 'power' },
-	{ slug: 'apc-smart-ups-srt-2200va-rm-nc', manufacturer: 'APC', model: 'Smart-UPS SRT 2200VA RM NC', u_height: 2, category: 'power' },
-	{ slug: 'apc-smart-ups-srt-5000va-200v', manufacturer: 'APC', model: 'Smart-UPS SRT 5000VA 200V', u_height: 3, category: 'power' },
-	{ slug: 'apc-smart-ups-srt-5000va-rm-208-230v-hw', manufacturer: 'APC', model: 'Smart-UPS SRT 5000VA RM 208/230V HW', u_height: 3, category: 'power' },
-	{ slug: 'apc-smart-ups-srt-5000va-rm-208v-iec', manufacturer: 'APC', model: 'Smart-UPS SRT 5000VA RM 208V IEC', u_height: 3, category: 'power' },
-	{ slug: 'apc-smart-ups-srt-5000va-rm-230v', manufacturer: 'APC', model: 'Smart-UPS SRT 5000VA RM 230V', u_height: 3, category: 'power' },
-	{ slug: 'apc-smart-ups-srt-6000va-rm-230v', manufacturer: 'APC', model: 'Smart-UPS SRT 6000VA RM 230V', u_height: 4, category: 'power' },
-	{ slug: 'apc-smart-ups-srt-8000va-rm-208v', manufacturer: 'APC', model: 'Smart-UPS SRT 8000VA RM 208V', u_height: 6, category: 'power' },
-	{ slug: 'apc-srt1000uxi-ncli', manufacturer: 'APC', model: 'Smart-UPS SRT1000UXI-NCLI', u_height: 2, category: 'power' },
-	{ slug: 'apc-srt1500rmxli-nc', manufacturer: 'APC', model: 'Smart-UPS SRT1500RMXLI-NC', u_height: 2, category: 'power' },
-	{ slug: 'apc-srt1500uxi-ncli', manufacturer: 'APC', model: 'Smart-UPS SRT1500UXI-NCLI', u_height: 2, category: 'power' },
-	{ slug: 'apc-srt3000rmxlt', manufacturer: 'APC', model: 'Smart-UPS SRT3000RMXLT', u_height: 2, category: 'power' },
-	{ slug: 'apc-srt3000uxi-ncli', manufacturer: 'APC', model: 'Smart-UPS SRT3000UXI-NCLI', u_height: 2, category: 'power' },
-	{ slug: 'apc-srt5krmxlt', manufacturer: 'APC', model: 'Smart-UPS SRT5KRMXLT', u_height: 3, category: 'power' },
-	{ slug: 'apc-srtg6kxli-ncli', manufacturer: 'APC', model: 'Smart-UPS SRTG6KXLI-NCLI', u_height: 4, category: 'power', airflow: 'passive' },
-	{ slug: 'apc-smt1000rmi2uc', manufacturer: 'APC', model: 'SMT1000RMI2UC', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smt1500rmi1u', manufacturer: 'APC', model: 'SMT1500RMI1U', u_height: 1, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smt1500rmi2u', manufacturer: 'APC', model: 'SMT1500RMI2U', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smt1500rmi2uc', manufacturer: 'APC', model: 'SMT1500RMI2UC', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smt1500rmi2unc', manufacturer: 'APC', model: 'SMT1500RMI2UNC', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smt2200rm2unc', manufacturer: 'APC', model: 'SMT2200RM2UNC', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smt2200rmi2unc', manufacturer: 'APC', model: 'SMT2200RMI2UNC', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smt3000rmi2u', manufacturer: 'APC', model: 'SMT3000RMI2U', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smt3000rmi2uc', manufacturer: 'APC', model: 'SMT3000RMI2UC', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smt3000rmi2unc', manufacturer: 'APC', model: 'SMT3000RMI2UNC', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smx120bp', manufacturer: 'APC', model: 'SMX120BP', u_height: 4, category: 'power' },
-	{ slug: 'apc-smx1500rm2unc', manufacturer: 'APC', model: 'SMX1500RM2UNC', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smx1500rmi2u', manufacturer: 'APC', model: 'SMX1500RMI2U', u_height: 2, category: 'power' },
-	{ slug: 'apc-smx2200hv', manufacturer: 'APC', model: 'SMX2200HV', u_height: 4, category: 'power' },
-	{ slug: 'apc-smx3000hvnc', manufacturer: 'APC', model: 'SMX3000HVNC', u_height: 4, category: 'power' },
-	{ slug: 'apc-smx3000rmhv2unc', manufacturer: 'APC', model: 'SMX3000RMHV2UNC', u_height: 2, category: 'power' },
-	{ slug: 'apc-smx3000rmlv2u', manufacturer: 'APC', model: 'SMX3000RMLV2U', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'apc-smx48rmbp2u', manufacturer: 'APC', model: 'SMX48RMBP2U', u_height: 2, category: 'power', airflow: 'passive' },
-	{ slug: 'cyberpower-cps-1220rms', manufacturer: 'CyberPower', model: 'CPS-1220RMS', u_height: 1, category: 'power', is_full_depth: false },
-	{ slug: 'cyberpower-cps1215rm', manufacturer: 'CyberPower', model: 'CPS1215RM', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'cyberpower-cps1215rms', manufacturer: 'CyberPower', model: 'CPS1215RMS', u_height: 1, category: 'power', is_full_depth: false },
-	{ slug: 'cyberpower-or1000lcdrm1u', manufacturer: 'CyberPower', model: 'OR1000LCDRM1U', u_height: 1, category: 'power' },
-	{ slug: 'cyberpower-or1500lcdrtxl2u', manufacturer: 'CyberPower', model: 'OR1500LCDRTXL2U', u_height: 2, category: 'power' },
-	{ slug: 'cyberpower-or2200lcdrt2u', manufacturer: 'CyberPower', model: 'OR2200LCDRT2U', u_height: 2, category: 'power' },
-	{ slug: 'cyberpower-or600elcdrm1u', manufacturer: 'CyberPower', model: 'OR600ELCDRM1U', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'cyberpower-pdu15m2f12r', manufacturer: 'CyberPower', model: 'PDU15M2F12R', u_height: 1, category: 'power', is_full_depth: false },
-	{ slug: 'cyberpower-pdu20bhviec12r', manufacturer: 'CyberPower', model: 'PDU20BHVIEC12R', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'cyberpower-pdu81005', manufacturer: 'CyberPower', model: 'PDU81005', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'eaton-5px1500irt', manufacturer: 'Eaton', model: '5PX1500iRT', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'eaton-5px2200irt', manufacturer: 'Eaton', model: '5PX2200IRT', u_height: 2, category: 'power' },
-	{ slug: 'eaton-5px3000irt2u', manufacturer: 'Eaton', model: '5PX3000IRT2U', u_height: 2, category: 'power' },
-	{ slug: 'eaton-5px3000rtn', manufacturer: 'Eaton', model: '5PX3000RTN', u_height: 2, category: 'power' },
-	{ slug: 'eaton-5sx1750rau', manufacturer: 'Eaton', model: '5SX1750RAU', u_height: 2, category: 'power' },
-	{ slug: 'eaton-9px-1000i-rt-2u', manufacturer: 'Eaton', model: '9PX 1000i RT 2U', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'eaton-9px-3000i-rt-2u', manufacturer: 'Eaton', model: '9PX 3000i RT 2U', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'eaton-9px3000irt3u', manufacturer: 'Eaton', model: '9PX3000iRT3U', u_height: 3, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'eaton-9px5kirtn', manufacturer: 'Eaton', model: '9PX5KIRTN', u_height: 3, category: 'power' },
-	{ slug: 'eaton-9px6k', manufacturer: 'Eaton', model: '9PX6K', u_height: 3, category: 'power' },
-	{ slug: 'eaton-9pxebm180', manufacturer: 'Eaton', model: '9PXEBM180', u_height: 3, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'eaton-9pxebm72rt2u', manufacturer: 'Eaton', model: '9PXEBM72RT2U', u_height: 2, category: 'power', airflow: 'front-to-rear' },
-	{ slug: 'eaton-emat08-10', manufacturer: 'Eaton', model: 'EMAT08-10', u_height: 1, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'eaton-pdumh30hvnet', manufacturer: 'Eaton', model: 'PDUMH30HVNET', u_height: 2, category: 'power', is_full_depth: false, airflow: 'passive' },
-	{ slug: 'eaton-pw103ba1u405', manufacturer: 'Eaton', model: 'PW103BA1U405', u_height: 1, category: 'power', is_full_depth: false },
-	{ slug: 'eaton-tripp-lite-b040-008-19', manufacturer: 'Eaton', model: 'Tripp Lite B040-008-19', u_height: 1, category: 'power', airflow: 'passive' },
-	{ slug: 'eaton-tripp-lite-b064-016-02-ipg', manufacturer: 'Eaton', model: 'Tripp Lite B064-016-02-IPG', u_height: 1, category: 'power', is_full_depth: false },
-	{ slug: 'eaton-tripp-lite-b064-032-01-ipg', manufacturer: 'Eaton', model: 'Tripp Lite B064-032-01-IPG', u_height: 1, category: 'power', is_full_depth: false },
-	{ slug: 'eaton-tripp-lite-b072-032-ip2', manufacturer: 'Eaton', model: 'Tripp Lite B072-032-IP2', u_height: 1, category: 'power', is_full_depth: false },
-	{ slug: 'eaton-tripp-lite-b096-016', manufacturer: 'Eaton', model: 'Tripp Lite B096-016', u_height: 1, category: 'power', is_full_depth: false },
 
 	// Patch Panels (3)
-	{ slug: '1u-fiber-patch-panel', model: 'Fiber Patch Panel', u_height: 1, category: 'patch-panel', is_full_depth: false },
-	{ slug: '24-port-patch-panel', model: 'Patch Panel (24-Port)', u_height: 1, category: 'patch-panel', is_full_depth: false },
-	{ slug: '48-port-patch-panel', model: 'Patch Panel (48-Port)', u_height: 2, category: 'patch-panel', is_full_depth: false },
+	{
+		slug: '1u-fiber-patch-panel',
+		model: 'Fiber Patch Panel',
+		u_height: 1,
+		category: 'patch-panel',
+		is_full_depth: false
+	},
+	{
+		slug: '24-port-patch-panel',
+		model: 'Patch Panel (24-Port)',
+		u_height: 1,
+		category: 'patch-panel',
+		is_full_depth: false
+	},
+	{
+		slug: '48-port-patch-panel',
+		model: 'Patch Panel (48-Port)',
+		u_height: 2,
+		category: 'patch-panel',
+		is_full_depth: false
+	},
 
-	// KVM/Console (2)
+	// KVM (2)
 	{ slug: '1u-console-drawer', model: 'Console Drawer', u_height: 1, category: 'kvm' },
 	{ slug: '1u-kvm', model: 'KVM Switch', u_height: 1, category: 'kvm' },
 
-	// AV/Media (15)
+	// AV/Media (8)
 	{ slug: '1u-amplifier', model: 'Amplifier', u_height: 1, category: 'av-media' },
 	{ slug: '2u-amplifier', model: 'Amplifier', u_height: 2, category: 'av-media' },
 	{ slug: '1u-audio-processor', model: 'Audio Processor', u_height: 1, category: 'av-media' },
@@ -438,25 +78,24 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
 	{ slug: '3u-power-amplifier', model: 'Power Amplifier', u_height: 3, category: 'av-media' },
 	{ slug: '1u-streaming-encoder', model: 'Streaming Encoder', u_height: 1, category: 'av-media' },
 	{ slug: '1u-video-switcher', model: 'Video Switcher', u_height: 1, category: 'av-media' },
-	{ slug: 'blackmagicdesign-atem-constellation-1-m-e-4k', manufacturer: 'Blackmagicdesign', model: 'ATEM Constellation 1 M/E 4k', u_height: 1, category: 'av-media', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'blackmagicdesign-atem-constellation-1-m-e-hd', manufacturer: 'Blackmagicdesign', model: 'ATEM Constellation 1 M/E HD', u_height: 1, category: 'av-media', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'blackmagicdesign-atem-constellation-2-m-e-4k', manufacturer: 'Blackmagicdesign', model: 'ATEM Constellation 2 M/E 4k', u_height: 1, category: 'av-media', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'blackmagicdesign-atem-constellation-2-m-e-hd', manufacturer: 'Blackmagicdesign', model: 'ATEM Constellation 2 M/E HD', u_height: 1, category: 'av-media', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'blackmagicdesign-atem-constellation-4-m-e-4k', manufacturer: 'Blackmagicdesign', model: 'ATEM Constellation 4 M/E 4k', u_height: 2, category: 'av-media', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'blackmagicdesign-atem-constellation-4-m-e-hd', manufacturer: 'Blackmagicdesign', model: 'ATEM Constellation 4 M/E HD', u_height: 2, category: 'av-media', is_full_depth: false, airflow: 'right-to-left' },
-	{ slug: 'blackmagicdesign-atem-constellation-8k', manufacturer: 'Blackmagicdesign', model: 'ATEM Constellation 8K', u_height: 2, category: 'av-media', is_full_depth: false, airflow: 'right-to-left' },
 
 	// Cooling (2)
 	{ slug: '1u-fan-panel', model: 'Fan Panel', u_height: 1, category: 'cooling', is_full_depth: false },
 	{ slug: '2u-fan-panel', model: 'Fan Panel', u_height: 2, category: 'cooling', is_full_depth: false },
 
 	// Shelves (4)
-	{ slug: '1u-cantilever-shelf', model: 'Cantilever Shelf', u_height: 1, category: 'shelf', is_full_depth: false },
+	{
+		slug: '1u-cantilever-shelf',
+		model: 'Cantilever Shelf',
+		u_height: 1,
+		category: 'shelf',
+		is_full_depth: false
+	},
 	{ slug: '1u-shelf', model: 'Shelf', u_height: 1, category: 'shelf' },
 	{ slug: '2u-shelf', model: 'Shelf', u_height: 2, category: 'shelf' },
 	{ slug: '1u-vented-shelf', model: 'Vented Shelf', u_height: 1, category: 'shelf' },
 
-	// Blank Panels (5)
+	// Blanks (5)
 	{ slug: '0-5u-blank', model: 'Blank Panel', u_height: 0.5, category: 'blank', is_full_depth: false },
 	{ slug: '1u-blank', model: 'Blank Panel', u_height: 1, category: 'blank', is_full_depth: false },
 	{ slug: '2u-blank', model: 'Blank Panel', u_height: 2, category: 'blank', is_full_depth: false },
@@ -464,28 +103,43 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
 	{ slug: '4u-blank', model: 'Blank Panel', u_height: 4, category: 'blank', is_full_depth: false },
 
 	// Cable Management (3)
-	{ slug: '1u-brush-panel', model: 'Brush Panel', u_height: 1, category: 'cable-management', is_full_depth: false },
-	{ slug: '1u-cable-manager', model: 'Cable Manager', u_height: 1, category: 'cable-management', is_full_depth: false },
-	{ slug: '2u-cable-manager', model: 'Cable Manager', u_height: 2, category: 'cable-management', is_full_depth: false },
+	{
+		slug: '1u-brush-panel',
+		model: 'Brush Panel',
+		u_height: 1,
+		category: 'cable-management',
+		is_full_depth: false
+	},
+	{
+		slug: '1u-cable-manager',
+		model: 'Cable Manager',
+		u_height: 1,
+		category: 'cable-management',
+		is_full_depth: false
+	},
+	{
+		slug: '2u-cable-manager',
+		model: 'Cable Manager',
+		u_height: 2,
+		category: 'cable-management',
+		is_full_depth: false
+	}
 ];
 
-// Cached starter library (computed once)
+// Cache the transformed library
 let cachedStarterLibrary: DeviceType[] | null = null;
 
 /**
- * Get the starter device type library
- * Returns a cached copy for performance
+ * Get all starter library devices
+ * Returns DeviceType[] with colors applied from category
  */
 export function getStarterLibrary(): DeviceType[] {
 	if (!cachedStarterLibrary) {
 		cachedStarterLibrary = STARTER_DEVICES.map((spec) => ({
 			slug: spec.slug,
-			u_height: spec.u_height,
-			manufacturer: spec.manufacturer,
 			model: spec.model,
+			u_height: spec.u_height,
 			is_full_depth: spec.is_full_depth,
-			airflow: spec.airflow as DeviceType['airflow'],
-			va_rating: spec.va_rating,
 			colour: CATEGORY_COLOURS[spec.category],
 			category: spec.category
 		}));
@@ -494,15 +148,21 @@ export function getStarterLibrary(): DeviceType[] {
 }
 
 /**
- * Find a device type in the starter library by slug
+ * Find a starter device by slug
  */
 export function findStarterDevice(slug: string): DeviceType | undefined {
 	return getStarterLibrary().find((d) => d.slug === slug);
 }
 
+// Cache for starter slugs
+let starterSlugsCache: Set<string> | null = null;
+
 /**
- * Get set of all starter library slugs for efficient lookup
+ * Get a Set of all starter device slugs for fast lookup
  */
 export function getStarterSlugs(): Set<string> {
-	return new Set(getStarterLibrary().map((d) => d.slug));
+	if (!starterSlugsCache) {
+		starterSlugsCache = new Set(getStarterLibrary().map((d) => d.slug));
+	}
+	return starterSlugsCache;
 }

--- a/src/tests/starterLibrary.test.ts
+++ b/src/tests/starterLibrary.test.ts
@@ -5,18 +5,25 @@ import { createLayout } from '$lib/utils/serialization';
 
 describe('Starter Device Type Library', () => {
 	describe('getStarterLibrary', () => {
-		it('returns 26 device types', () => {
+		it('returns 43 generic device types', () => {
 			const deviceTypes = getStarterLibrary();
-			expect(deviceTypes).toHaveLength(26);
+			expect(deviceTypes).toHaveLength(43);
 		});
 
-		it('most categories have at least one starter device type', () => {
+		it('all categories have at least one starter device type', () => {
 			const deviceTypes = getStarterLibrary();
 			const categoriesWithDevices = new Set(deviceTypes.map((d) => d.category));
 
-			// At minimum, these core categories must have devices
+			// All categories should be represented
 			expect(categoriesWithDevices.has('server')).toBe(true);
 			expect(categoriesWithDevices.has('network')).toBe(true);
+			expect(categoriesWithDevices.has('storage')).toBe(true);
+			expect(categoriesWithDevices.has('power')).toBe(true);
+			expect(categoriesWithDevices.has('patch-panel')).toBe(true);
+			expect(categoriesWithDevices.has('kvm')).toBe(true);
+			expect(categoriesWithDevices.has('av-media')).toBe(true);
+			expect(categoriesWithDevices.has('cooling')).toBe(true);
+			expect(categoriesWithDevices.has('shelf')).toBe(true);
 			expect(categoriesWithDevices.has('blank')).toBe(true);
 			expect(categoriesWithDevices.has('cable-management')).toBe(true);
 		});
@@ -56,9 +63,17 @@ describe('Starter Device Type Library', () => {
 				expect(deviceType.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
 			});
 		});
+
+		it('no devices have manufacturer (all generic)', () => {
+			const deviceTypes = getStarterLibrary();
+
+			deviceTypes.forEach((deviceType) => {
+				expect(deviceType.manufacturer).toBeUndefined();
+			});
+		});
 	});
 
-	describe('server category (3 items)', () => {
+	describe('server category (4 items)', () => {
 		it('includes Server (1U)', () => {
 			const library = getStarterLibrary();
 			const device = library.find((d) => d.model === 'Server' && d.u_height === 1);
@@ -73,6 +88,13 @@ describe('Starter Device Type Library', () => {
 			expect(device?.category).toBe('server');
 		});
 
+		it('includes Server (3U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Server' && d.u_height === 3);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('server');
+		});
+
 		it('includes Server (4U)', () => {
 			const library = getStarterLibrary();
 			const device = library.find((d) => d.model === 'Server' && d.u_height === 4);
@@ -81,7 +103,7 @@ describe('Starter Device Type Library', () => {
 		});
 	});
 
-	describe('network category (3 items)', () => {
+	describe('network category (4 items)', () => {
 		it('includes Switch (24-Port)', () => {
 			const library = getStarterLibrary();
 			const device = library.find((d) => d.model === 'Switch (24-Port)');
@@ -98,16 +120,90 @@ describe('Starter Device Type Library', () => {
 			expect(device?.category).toBe('network');
 		});
 
-		it('includes Router/Firewall', () => {
+		it('includes Router/Firewall (1U)', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Router/Firewall');
+			const device = library.find((d) => d.model === 'Router/Firewall' && d.u_height === 1);
 			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(1);
+			expect(device?.category).toBe('network');
+		});
+
+		it('includes Router/Firewall (2U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Router/Firewall' && d.u_height === 2);
+			expect(device).toBeDefined();
 			expect(device?.category).toBe('network');
 		});
 	});
 
-	describe('patch-panel category (2 items)', () => {
+	describe('storage category (4 items)', () => {
+		it('includes Storage (1U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Storage' && d.u_height === 1);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('storage');
+		});
+
+		it('includes Storage (2U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Storage' && d.u_height === 2);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('storage');
+		});
+
+		it('includes Storage (3U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Storage' && d.u_height === 3);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('storage');
+		});
+
+		it('includes Storage (4U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Storage' && d.u_height === 4);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('storage');
+		});
+	});
+
+	describe('power category (4 items)', () => {
+		it('includes PDU (1U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'PDU' && d.u_height === 1);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('power');
+		});
+
+		it('includes PDU (2U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'PDU' && d.u_height === 2);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('power');
+		});
+
+		it('includes UPS (2U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'UPS' && d.u_height === 2);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('power');
+		});
+
+		it('includes UPS (4U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'UPS' && d.u_height === 4);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('power');
+		});
+	});
+
+	describe('patch-panel category (3 items)', () => {
+		it('includes Fiber Patch Panel', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Fiber Patch Panel');
+			expect(device).toBeDefined();
+			expect(device?.u_height).toBe(1);
+			expect(device?.category).toBe('patch-panel');
+		});
+
 		it('includes Patch Panel (24-Port)', () => {
 			const library = getStarterLibrary();
 			const device = library.find((d) => d.model === 'Patch Panel (24-Port)');
@@ -125,59 +221,10 @@ describe('Starter Device Type Library', () => {
 		});
 	});
 
-	describe('storage category (3 items)', () => {
-		it('includes Storage (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Storage' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('storage');
-		});
-
-		it('includes Storage (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Storage' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('storage');
-		});
-
-		it('includes Storage (4U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Storage' && d.u_height === 4);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('storage');
-		});
-	});
-
-	describe('power category (3 items)', () => {
-		it('includes PDU', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'PDU');
-			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(1);
-			expect(device?.category).toBe('power');
-		});
-
-		it('includes UPS (2U) with va_rating', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'UPS' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('power');
-			expect(device?.va_rating).toBe(1500);
-		});
-
-		it('includes UPS (4U) with va_rating', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'UPS' && d.u_height === 4);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('power');
-			expect(device?.va_rating).toBe(3000);
-		});
-	});
-
 	describe('kvm category (2 items)', () => {
-		it('includes KVM', () => {
+		it('includes KVM Switch', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'KVM');
+			const device = library.find((d) => d.model === 'KVM Switch');
 			expect(device).toBeDefined();
 			expect(device?.category).toBe('kvm');
 		});
@@ -190,61 +237,68 @@ describe('Starter Device Type Library', () => {
 		});
 	});
 
-	describe('av-media category (2 items)', () => {
-		it('includes Receiver', () => {
+	describe('av-media category (8 items)', () => {
+		it('includes Amplifier (1U)', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Receiver');
+			const device = library.find((d) => d.model === 'Amplifier' && d.u_height === 1);
 			expect(device).toBeDefined();
 			expect(device?.category).toBe('av-media');
 		});
 
-		it('includes Amplifier', () => {
+		it('includes Amplifier (2U)', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Amplifier');
+			const device = library.find((d) => d.model === 'Amplifier' && d.u_height === 2);
 			expect(device).toBeDefined();
 			expect(device?.category).toBe('av-media');
+		});
+
+		it('includes AV Receiver (1U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'AV Receiver' && d.u_height === 1);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('av-media');
+		});
+
+		it('includes Power Amplifier (3U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Power Amplifier');
+			expect(device).toBeDefined();
+			expect(device?.u_height).toBe(3);
+			expect(device?.category).toBe('av-media');
+		});
+
+		it('has 8 av-media devices total', () => {
+			const library = getStarterLibrary();
+			const avDevices = library.filter((d) => d.category === 'av-media');
+			expect(avDevices).toHaveLength(8);
 		});
 	});
 
-	describe('cooling category (1 item)', () => {
-		it('includes Fan Panel', () => {
+	describe('cooling category (2 items)', () => {
+		it('includes Fan Panel (1U)', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Fan Panel');
+			const device = library.find((d) => d.model === 'Fan Panel' && d.u_height === 1);
 			expect(device).toBeDefined();
 			expect(device?.category).toBe('cooling');
 		});
 
-		it('does NOT include Blanking Fan (removed)', () => {
+		it('includes Fan Panel (2U)', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blanking Fan');
-			expect(device).toBeUndefined();
+			const device = library.find((d) => d.model === 'Fan Panel' && d.u_height === 2);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('cooling');
 		});
 	});
 
-	describe('blank category (3 items)', () => {
-		it('includes Blank (0.5U)', () => {
+	describe('shelf category (4 items)', () => {
+		it('includes Cantilever Shelf', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank' && d.u_height === 0.5);
+			const device = library.find((d) => d.model === 'Cantilever Shelf');
 			expect(device).toBeDefined();
-			expect(device?.category).toBe('blank');
+			expect(device?.u_height).toBe(1);
+			expect(device?.category).toBe('shelf');
 		});
 
-		it('includes Blank (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('blank');
-		});
-
-		it('includes Blank (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('blank');
-		});
-	});
-
-	describe('shelf category (2 items)', () => {
 		it('includes Shelf (1U)', () => {
 			const library = getStarterLibrary();
 			const device = library.find((d) => d.model === 'Shelf' && d.u_height === 1);
@@ -259,10 +313,11 @@ describe('Starter Device Type Library', () => {
 			expect(device?.category).toBe('shelf');
 		});
 
-		it('does NOT include Shelf (4U) (removed)', () => {
+		it('includes Vented Shelf', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Shelf' && d.u_height === 4);
-			expect(device).toBeUndefined();
+			const device = library.find((d) => d.model === 'Vented Shelf');
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('shelf');
 		});
 
 		it('shelf device types have Dracula comment colour', () => {
@@ -275,7 +330,44 @@ describe('Starter Device Type Library', () => {
 		});
 	});
 
-	describe('cable-management category (2 items)', () => {
+	describe('blank category (5 items)', () => {
+		it('includes Blank Panel (0.5U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 0.5);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('blank');
+		});
+
+		it('includes Blank Panel (1U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 1);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('blank');
+		});
+
+		it('includes Blank Panel (2U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 2);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('blank');
+		});
+
+		it('includes Blank Panel (3U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 3);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('blank');
+		});
+
+		it('includes Blank Panel (4U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 4);
+			expect(device).toBeDefined();
+			expect(device?.category).toBe('blank');
+		});
+	});
+
+	describe('cable-management category (3 items)', () => {
 		it('includes Brush Panel', () => {
 			const library = getStarterLibrary();
 			const device = library.find((d) => d.model === 'Brush Panel');
@@ -284,11 +376,17 @@ describe('Starter Device Type Library', () => {
 			expect(device?.category).toBe('cable-management');
 		});
 
-		it('includes Cable Management', () => {
+		it('includes Cable Manager (1U)', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Cable Management');
+			const device = library.find((d) => d.model === 'Cable Manager' && d.u_height === 1);
 			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(1);
+			expect(device?.category).toBe('cable-management');
+		});
+
+		it('includes Cable Manager (2U)', () => {
+			const library = getStarterLibrary();
+			const device = library.find((d) => d.model === 'Cable Manager' && d.u_height === 2);
+			expect(device).toBeDefined();
 			expect(device?.category).toBe('cable-management');
 		});
 
@@ -296,43 +394,17 @@ describe('Starter Device Type Library', () => {
 			const library = getStarterLibrary();
 			const cableDevices = library.filter((d) => d.category === 'cable-management');
 
-			expect(cableDevices).toHaveLength(2);
+			expect(cableDevices).toHaveLength(3);
 			cableDevices.forEach((device) => {
 				expect(device.colour).toBe('#6272A4');
 			});
 		});
 	});
 
-	describe('removed items', () => {
-		it('does NOT include Generic (removed)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Generic');
-			expect(device).toBeUndefined();
-		});
-
-		it('does NOT include Router (merged into Router/Firewall)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Router');
-			expect(device).toBeUndefined();
-		});
-
-		it('does NOT include Firewall (merged into Router/Firewall)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Firewall');
-			expect(device).toBeUndefined();
-		});
-
-		it('does NOT include Switch without port count (renamed to specific port counts)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Switch');
-			expect(device).toBeUndefined();
-		});
-	});
-
 	describe('slug generation', () => {
-		it('generates correct slug for Router/Firewall', () => {
+		it('generates correct slug for Router/Firewall (1U)', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Router/Firewall');
+			const device = library.find((d) => d.model === 'Router/Firewall' && d.u_height === 1);
 			expect(device?.slug).toBe('1u-router-firewall');
 		});
 
@@ -342,16 +414,16 @@ describe('Starter Device Type Library', () => {
 			expect(device?.slug).toBe('24-port-switch');
 		});
 
-		it('generates correct slug for Blank (0.5U)', () => {
+		it('generates correct slug for Blank Panel (0.5U)', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank' && d.u_height === 0.5);
+			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 0.5);
 			expect(device?.slug).toBe('0-5u-blank');
 		});
 
-		it('generates correct slug for Cable Management', () => {
+		it('generates correct slug for Cable Manager (1U)', () => {
 			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Cable Management');
-			expect(device?.slug).toBe('1u-cable-management');
+			const device = library.find((d) => d.model === 'Cable Manager' && d.u_height === 1);
+			expect(device?.slug).toBe('1u-cable-manager');
 		});
 	});
 
@@ -388,11 +460,11 @@ describe('Starter Device Type Library', () => {
 			expect(layout.device_types.length).toBe(0);
 		});
 
-		it('starter library is available as a constant', () => {
+		it('starter library contains only generic devices', () => {
 			const starterLibrary = getStarterLibrary();
 
-			// Library should have a substantial number of devices (generic + branded)
-			expect(starterLibrary.length).toBeGreaterThanOrEqual(400);
+			// Library should have 43 generic devices
+			expect(starterLibrary.length).toBe(43);
 			expect(starterLibrary[0]?.slug).toBeTruthy();
 		});
 


### PR DESCRIPTION
## Summary

- Reduced starterLibrary.ts from 508 lines (61KB) to 168 lines (5.6KB)
- Created 9 new brand packs: Fortinet, Eaton, Netgear, Palo Alto, QNAP, Lenovo, CyberPower, Netgate, Blackmagic Design
- Merged devices from starterLibrary into 8 existing brand packs (deduping by slug)
- Starter library now contains only 43 generic devices (no manufacturer)
- Total brands: 17 (was 8)
- Total branded devices: ~500+ across all brand packs

## Details

The starter library was bloated with 424 devices, of which only 43 were generic fallback devices. All branded devices have been moved to their appropriate brand pack files for better organization and maintainability.

### New Brand Packs (9)
| Brand | Devices | Category |
|-------|---------|----------|
| Fortinet | 20 | Network |
| Netgear | 18 | Network |
| Palo Alto | 15 | Network |
| Netgate | 8 | Network |
| QNAP | 13 | Storage |
| Lenovo | 10 | Server |
| Eaton | 20 | Power |
| CyberPower | 10 | Power |
| Blackmagic Design | 7 | AV/Media |

### Starter Library (Generic Only)
- 4 Servers (1U-4U)
- 4 Network (Router/Firewall, Switches)
- 4 Storage (1U-4U)
- 4 Power (PDU, UPS)
- 3 Patch Panels
- 2 KVM
- 8 AV/Media
- 2 Cooling
- 4 Shelves
- 5 Blanks
- 3 Cable Management

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] starterLibrary tests pass (59 tests)
- [x] deviceFilters tests pass
- [ ] Manual verification in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)