### PR TITLE
fix: dismiss tooltip on mousedown before dialog opens

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -51,6 +51,11 @@
 	function handleBlur() {
 		hideTooltip();
 	}
+
+	function handleMouseDown() {
+		// Hide tooltip immediately on click (before dialog opens)
+		hideTooltip();
+	}
 </script>
 
 <div class="tooltip-wrapper">
@@ -59,6 +64,7 @@
 		class="tooltip-trigger"
 		onmouseenter={handleMouseEnter}
 		onmouseleave={handleMouseLeave}
+		onmousedown={handleMouseDown}
 		onfocusin={handleFocus}
 		onfocusout={handleBlur}
 	>


### PR DESCRIPTION
Fixes #198

## Summary
- Added `onmousedown` handler to hide tooltip immediately when clicked
- Prevents tooltip from remaining visible behind/over dialogs

## Technical Details
The tooltip was only hiding on `mouseleave` or `focusout`. When a button was clicked to open a dialog, the tooltip would remain visible because the mouse was still over the button when the dialog opened.

Adding `onmousedown` ensures the tooltip hides before the click event fires and the dialog opens.

## Test plan
- [ ] Hover over Help button until tooltip appears
- [ ] Click button → tooltip should disappear immediately
- [ ] Dialog opens without tooltip visible behind it
- [ ] Works for all toolbar buttons with tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)